### PR TITLE
Install stakater/reflector for cross-namespace Secret mirror

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -6,6 +6,7 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./metrics-server/ks.yaml
+  - ./reflector/ks.yaml
   - ./reloader/ks.yaml
 # local-path-provisioner is WSL-only (MS-01 uses Rook Ceph). Added back
 # via kubernetes/clusters/wsl/apps/kustomization.yaml.

--- a/kubernetes/apps/kube-system/reflector/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reflector/app/helmrelease.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: reflector
+  namespace: kube-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: reflector
+      version: 10.0.45
+      sourceRef:
+        kind: HelmRepository
+        name: emberstack
+        namespace: flux-system
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    replicaCount: 1

--- a/kubernetes/apps/kube-system/reflector/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/reflector/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/reflector/ks.yaml
+++ b/kubernetes/apps/kube-system/reflector/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: reflector
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/kube-system/reflector/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/flux/meta/helm/emberstack.yaml
+++ b/kubernetes/flux/meta/helm/emberstack.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: emberstack
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://emberstack.github.io/helm-charts

--- a/kubernetes/flux/meta/helm/kustomization.yaml
+++ b/kubernetes/flux/meta/helm/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ./cilium.yaml
   - ./cloudnative-pg.yaml
   - ./descheduler.yaml
+  - ./emberstack.yaml
   - ./external-dns.yaml
   - ./flannel.yaml
   - ./grafana.yaml


### PR DESCRIPTION
## Summary

The previous PR (#1207) added \`inheritedMetadata.annotations\` on the
cnpg postgres Cluster so stakater/reflector would mirror the
generated \`postgres-app\` Secret from \`databases\` to \`production\`,
where mealie consumes it. But reflector wasn't actually installed in
the cluster — what's running is \`image-reflector-controller\` (a Flux
component, totally different).

This PR adds reflector via a HelmRelease in \`kube-system\` from the
emberstack chart repo. Once reconciled:
- \`databases/postgres-app\` gets mirrored to \`production/postgres-app\`
- mealie's \`CreateContainerConfigError\` clears
- mealie boots, connects to postgres-rw, recipes.tnwks.us comes online

## Test plan
- [ ] reflector deploy ready in kube-system
- [ ] \`kubectl get secret -n production postgres-app\` returns the mirror
- [ ] mealie pod starts, no \`CreateContainerConfigError\`
- [ ] \`recipes.tnwks.us\` returns HTTP 200 (or login page) instead of 503

## Open follow-ups (not in this PR)
- Prometheus pod stuck \`CrashLoopBackOff\` with \`permission denied:
  /prometheus/queries.active\` — Talos + local-path fsGroup interaction.
  Cleanest fix on WSL: switch prometheus storage to emptyDir (12h
  dev-cluster retention doesn't need persistence).