### PR TITLE
fix: mealie postgres dbname; prom fsGroup; wizarr 4.2.0

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -221,6 +221,17 @@ spec:
         ruleSelectorNilUsesHelmValues: false
         scrapeInterval: 1m
         serviceMonitorSelectorNilUsesHelmValues: false
+        # fsGroupChangePolicy: Always — without this, kubelet's
+        # OnRootMismatch default doesn't recursively chown the local-path
+        # PVC dir on Talos, leading to "permission denied" on
+        # /prometheus/queries.active when the prometheus container
+        # (UID 1000:2000) tries to write.
+        securityContext:
+          fsGroup: 2000
+          runAsGroup: 2000
+          runAsNonRoot: true
+          runAsUser: 1000
+          fsGroupChangePolicy: Always
         storageSpec:
           volumeClaimTemplate:
             spec:

--- a/kubernetes/apps/production/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/production/mealie/app/helmrelease.yaml
@@ -50,11 +50,11 @@ spec:
         value: "postgres-rw.databases.svc.cluster.local"
       - name: POSTGRES_PORT
         value: "5432"
+      # cnpg's `postgres-app` Secret only carries username/password/pgpass.
+      # The DB name comes from cluster.yaml's `bootstrap.initdb.database`
+      # field (`app`).
       - name: POSTGRES_DB
-        valueFrom:
-          secretKeyRef:
-            name: postgres-app
-            key: dbname
+        value: "app"
 
     image:
       repository: docker.io/hkotel/mealie

--- a/kubernetes/apps/production/wizarr/app/helmrelease.yaml
+++ b/kubernetes/apps/production/wizarr/app/helmrelease.yaml
@@ -32,9 +32,9 @@ spec:
         reloader.stakater.com/auto: "true"
     image:
       repository: ghcr.io/wizarrrr/wizarr
-      # SHA pin removed — the original digest was GC'd by ghcr.io.
-      # Renovate will re-pin to a current digest on next run.
-      tag: 3.5.2
+      # 3.5.2 was GC'd from ghcr.io entirely (tag and digest gone).
+      # Wizarr's 4.x line has been out for a while; bump to current.
+      tag: 4.2.0
     env:
       TZ: ${TIMEZONE}
       APP_URL: https://invite.${SECRET_DOMAIN}


### PR DESCRIPTION
## Summary

Follow-ups observed after #1207 + #1208 reconciled.

1. **mealie** \`couldn't find key dbname in Secret postgres-app\` —
   cnpg 1.20.2's app Secret only carries \`username\`, \`password\`,
   \`pgpass\`. Set \`POSTGRES_DB\` to the literal \`"app"\` (matches
   \`bootstrap.initdb.database\` in cluster.yaml).

2. **prometheus** \`CrashLoopBackOff: permission denied:
   /prometheus/queries.active\` — kubelet's default
   \`fsGroupChangePolicy=OnRootMismatch\` doesn't recursively chown
   the local-path PVC dir on Talos. Setting it to \`Always\` forces
   the chown on every pod start.

3. **wizarr** 3.5.2 was GC'd from ghcr.io entirely (tag and digest
   both gone). Bump to current stable 4.2.0 (4.x line was already
   out via Renovate's pending PR).

## Test plan
- [ ] mealie pod transitions out of CreateContainerConfigError into
      Running, \`recipes.tnwks.us\` returns app login (HTTP 200)
- [ ] prometheus pod Running 3/3, no CrashLoop
- [ ] wizarr pulls 4.2.0 and \`invite.tnwks.us\` returns the welcome page