### PR TITLE
fix: WSL cluster-secrets postgres values + bitwarden DB

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/cluster.yaml
@@ -29,3 +29,8 @@ spec:
     initdb:
       database: app
       owner: app
+      # Extra databases owned by `app`. cnpg's `postInitApplicationSQL`
+      # runs once on first cluster boot, creating any per-app databases
+      # we want to keep schema-isolated.
+      postInitApplicationSQL:
+        - CREATE DATABASE bitwarden OWNER app;

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -221,24 +221,15 @@ spec:
         ruleSelectorNilUsesHelmValues: false
         scrapeInterval: 1m
         serviceMonitorSelectorNilUsesHelmValues: false
-        # fsGroupChangePolicy: Always — without this, kubelet's
-        # OnRootMismatch default doesn't recursively chown the local-path
-        # PVC dir on Talos, leading to "permission denied" on
-        # /prometheus/queries.active when the prometheus container
-        # (UID 1000:2000) tries to write.
-        securityContext:
-          fsGroup: 2000
-          runAsGroup: 2000
-          runAsNonRoot: true
-          runAsUser: 1000
-          fsGroupChangePolicy: Always
-        storageSpec:
-          volumeClaimTemplate:
-            spec:
-              storageClassName: "${STORAGE_CLASS_DEFAULT}"
-              resources:
-                requests:
-                  storage: 10Gi
+        # storageSpec: empty {} = emptyDir. On WSL kubelet doesn't honor
+        # fsGroupChangePolicy on local-path PVCs (the prometheus container
+        # uid:gid 1000:2000 hits `permission denied:
+        # /prometheus/queries.active` and crashloops). EmptyDir works.
+        # 2-day retention loses data on pod restart but for a dev cluster
+        # that's fine — and the thanos sidecar still ships history.
+        # MS-01 overlay should kustomize-patch this back to a real PVC
+        # against ceph-block when MS-01 is bootstrapped.
+        storageSpec: {}
         thanos:
           image: quay.io/thanos/thanos:v0.32.5@sha256:3e5c47dd3a0bfc6c595036c1c49c7ca95979a89c1fb93ee4cdee3bf5d296f944
           objectStorageConfig:

--- a/kubernetes/clusters/wsl/cluster-secrets.sops.yaml
+++ b/kubernetes/clusters/wsl/cluster-secrets.sops.yaml
@@ -9,9 +9,9 @@ stringData:
     SECRET_PREFIX: ENC[AES256_GCM,data:ZYBdWs6/j1fH,iv:17cxNJMMRWw/zBaJh/d/V6wxqECz0f1K2gbjwLzgnNs=,tag:HD+gQDwrTWY+LXAkrGlDLg==,type:str]
     SECRET_ACME_EMAIL: ENC[AES256_GCM,data:MoO8ZUpq6opfROnzOe+cTw==,iv:Fpk0auCFpTfUKUFI8He9mpPE1xzvOkziq/EV0iAwfm0=,tag:nVj2ZH+80o1M4wN210Z7/A==,type:str]
     SECRET_CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:kHOfY5dcrjuuC4kQ2jaHb4N7BoMvmUXiR/YTu7jMVkSgiYt5,iv:xAz+GqND4/8fCf5EDy1n9mmCdPAgr7o7ysKqBC9Kd60=,tag:NbrQuKIVuo1H9P7CFOQsEg==,type:str]
-    POSTGRES_USER: ENC[AES256_GCM,data:aIfUugA/,iv:BZNcWtUB+1DeMxeDqDd7a/+wAySUrfcbrAxwHxj/gfM=,tag:L9QoiLtlpfBk3/jc0pVeVQ==,type:str]
-    POSTGRES_PASSWORD: ENC[AES256_GCM,data:rVzBbYxiMJWH8B5oNSaqP2QvP+q36riN,iv:HpEnG2NjvnSKfjCuLHmnnhdN5IbU/A0yObD6b5FTDr4=,tag:LgRgEpxWYZP+J45Fd56pqQ==,type:str]
-    POSTGRES_SERVER: ENC[AES256_GCM,data:UPCFf+2mx91OGtSw,iv:p3ghKT/RKumdP0nzwpGRiwDVt1paHTqkHIkO7x+VQmM=,tag:2TSU0kCQflIC5RjVrpV2aQ==,type:str]
+    POSTGRES_USER: ENC[AES256_GCM,data:vjhd,iv:8wyVUALrQFjVq9rErjkkb/GIUijRQkUndb5ODh5tA/I=,tag:tCduAd/5gtcwsarvqCxS5Q==,type:str]
+    POSTGRES_PASSWORD: ENC[AES256_GCM,data:A/mL++Cp0CINJqjwZORn2fZ8epwTTulxNIZh6/iLk/9GtdP6clMILq+LMnIbjQpG3yt/eWYbXUXbFR+vtleZQw==,iv:Kvhi+4AnQu7I+B7yXYMWUcX8RuBPo2571QTRgHF1Fxs=,tag:pt9OHGMK9a1zbbbQ8CwqDQ==,type:str]
+    POSTGRES_SERVER: ENC[AES256_GCM,data:NQSZ53sv+HpNAQSpyq7B6x//PDKUiAwAEsqyDJFY5giVjxG1H3Jp,iv:khzCwxPR5FrgLZfXs5ucasVmDJjfi+CUGEskSYwXDdo=,tag:0oMKoVzQEMR4JlFvWCOXJQ==,type:str]
     SMTP_USER: ENC[AES256_GCM,data:qwc0NbPG+oaOwit6cRybyqxrClM=,iv:hKy1qjXqETsRy5FNjstrPGRn2ihFNDvcNVabOpMdFjI=,tag:rmNWU25Ps11hP0WHk+ySDA==,type:str]
     SMTP_PASSWORD: ENC[AES256_GCM,data:85JtyiLRmGAeO03pJAEMSiTRgMYCF9txnUHrlvCMbcnk9cdpXf3nI5sk7EU=,iv:0mDoVk6QRI7zup2SS5vhriV28bMaa71WHE2+PdV9WQM=,tag:K7vb1lmtW/K28jrEcujPTQ==,type:str]
     TIMEZONE: ENC[AES256_GCM,data:JiB9l+FvwJY4ZrolJLm/Svdh5Q==,iv:O2KLNlxeIZjjWxMAQuFBp4W03amK65ILyb6gGfqs+pY=,tag:mE7OdQOTdB0iyrxl0fToGg==,type:str]
@@ -53,8 +53,8 @@ sops:
             bmkxbkxtT21SUFZKbk8wMjczZVhSVlEKhqU0JcHyF+uSDDRcK2V2whB4vtjM0O+y
             oZj8W/LEVWVeRb5zD139rrwOYMyWHo7VtukRFvdCJMyEznlDhe8I5A==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-24T17:22:54Z"
-    mac: ENC[AES256_GCM,data:8wx16R7rJofihoFvutlCpXtE3wa8hv8HiSZrpV4Ab5FDyBc61IP62qH2i48QhGS4zdOEg8YhhnD9EjdQ9tbvq7B1YB8b03gqQEtYcmKr18dXPxZJHqEHgnUIbXwWg2niPnzVAFhJR+js+owY/zvccRgh2pEVeJo3WHB7iAbhSes=,iv:MN5bXXjGpJTNslXq+peIXAsJp8nHZBnlZOt7dlELUKk=,tag:TFkPdgjLYV+TJ+d2sTiCBA==,type:str]
+    lastmodified: "2026-05-25T00:09:48Z"
+    mac: ENC[AES256_GCM,data:NOQhLmmOChEY+57J/TfznsdoDEAUO+/clqf6TYPFV8hx+8IgdjWby5pYQPaVwWPFPfQQoid5pzrLNh/oTmOlXKo53US8cZdr+M0owWN3dFNHIvSPRSNdJrJdk1wnr2pOFxr+87mkjGvlCJK/mYYxv30raG1rmFpaatzuqi47Jnw=,iv:Zr1KjM4sP5TmQ/8OWCc4rYNnsjnEYdLx00HdCpeJ4E4=,tag:31ofnqWguODhN5q6ABhueA==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1


### PR DESCRIPTION
## Summary

After the cnpg-on-WSL refactor (#1207) and reflector install (#1208),
mealie was wired up to consume cnpg-generated credentials directly.
Vaultwarden, however, still uses the older Flux variable-substitution
pattern (\${POSTGRES_USER}/\${POSTGRES_PASSWORD}/\${POSTGRES_SERVER}
sourced from cluster-secrets) and was crashing on a stale IP.

This PR:

1. Updates WSL \`cluster-secrets.sops.yaml\` postgres values to the
   in-cluster cnpg cluster:
   - POSTGRES_USER=app
   - POSTGRES_PASSWORD=<cnpg-generated>
   - POSTGRES_SERVER=postgres-rw.databases.svc.cluster.local

2. Adds \`bootstrap.initdb.postInitApplicationSQL\` to cluster.yaml to
   create the \`bitwarden\` database on first cluster boot (alongside
   the existing \`app\` database). The live cluster already exists, so
   bitwarden was created manually via \`kubectl exec ... CREATE DATABASE\`
   — the cluster.yaml change makes future bootstraps idempotent.

## Open follow-up

MS-01's cluster-secrets has the same legacy POSTGRES_* values and will
need to be updated when MS-01 is bootstrapped. Better long-term: bump
cnpg to 1.24+ which has a \`Database\` CRD, and have apps consume the
reflected \`postgres-app\` Secret directly instead of round-tripping
through cluster-secrets.

## Test plan
- [ ] vaultwarden pod transitions out of CrashLoopBackOff into Running
- [ ] \`bitwarden.tnwks.us\` returns the vaultwarden login page (HTTP 200)