### PR TITLE
chore(renovate): modernize config for Renovate 37+

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     "docker:enableMajor",
     ":disableRateLimiting",
     ":dependencyDashboard",
@@ -21,30 +21,39 @@
   "suppressNotifications": ["prIgnoreNotification"],
   "rebaseWhen": "conflicted",
   "schedule": ["before 7am"],
+  // Cap the volume during the modernization sweep so reviews stay tractable.
+  // Tighten further (or remove) once the bulk catch-up settles.
+  "prHourlyLimit": 4,
+  "prConcurrentLimit": 12,
   "pre-commit": {
     "enabled": true
   },
   "flux": {
-    "fileMatch": ["kubernetes/.+\\.ya?ml$"]
-  },
-  "helm-values": {
-    "fileMatch": ["kubernetes/.+\\.ya?ml$"]
-  },
-  "kubernetes": {
-    "fileMatch": [
-      "ansible/.+\\.ya?ml(\\.j2)?$",
-      "kubernetes/.+\\.ya?ml$"
+    "managerFilePatterns": [
+      "/kubernetes/.+\\.ya?ml$/"
     ]
   },
-  "regexManagers": [
+  "helm-values": {
+    "managerFilePatterns": [
+      "/kubernetes/.+\\.ya?ml$/"
+    ]
+  },
+  "kubernetes": {
+    "managerFilePatterns": [
+      "/ansible/.+\\.ya?ml(\\.j2)?$/",
+      "/kubernetes/.+\\.ya?ml$/"
+    ]
+  },
+  "customManagers": [
     {
-      "description": "Process various other dependencies",
-      "fileMatch": [
-        "ansible/.+\\.ya?ml(\\.j2)?$",
-        "kubernetes/.+\\.ya?ml$"
+      "customType": "regex",
+      "description": "Process generic # renovate: datasource=… depName=… version comments",
+      "managerFilePatterns": [
+        "/ansible/.+\\.ya?ml(\\.j2)?$/",
+        "/kubernetes/.+\\.ya?ml$/"
       ],
       "matchStrings": [
-        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( registryUrl=(?<registryUrl>\\S+))?\n.*?\"(?<currentValue>.*)\"\n"
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( registryUrl=(?<registryUrl>\\S+))?\\n.*?[\"']?(?<currentValue>[^\"'\\s]+)[\"']?\\n"
       ],
       "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}"
     }

--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -4,12 +4,22 @@
     {
       "description": "Flux Group",
       "groupName": "Flux",
-      "matchPackagePatterns": ["flux"],
+      "matchPackageNames": ["/flux/"],
       "matchDatasources": ["docker", "github-tags"],
       "versioning": "semver",
       "group": {
         "commitMessageTopic": "{{{groupName}}} group"
       },
+      "separateMinorPatch": true
+    },
+    {
+      // Bumping bjw-s `app-template` is a fleet-wide schema change. Group
+      // every chart bump into one PR so the canary→sweep migration can be
+      // reviewed and merged as a single, cohesive change.
+      "description": "bjw-s app-template fleet group",
+      "groupName": "bjw-s app-template",
+      "matchDatasources": ["helm"],
+      "matchPackageNames": ["app-template"],
       "separateMinorPatch": true
     }
   ]


### PR DESCRIPTION
## Summary

- Replaces deprecated keys/presets so Renovate 37+ stops silently dropping rules
- Adds an `app-template` group + sweep-friendly PR caps for the upcoming version-modernization wave

## Changes

- `config:base` → `config:recommended` (preset renamed)
- `regexManagers` → `customManagers` with `customType: "regex"` (old key removed in 37+)
- `matchPackagePatterns: ["flux"]` → `matchPackageNames: ["/flux/"]` (regex form)
- All `fileMatch` → `managerFilePatterns` with `/.../` delimiters
- New `prHourlyLimit: 4` / `prConcurrentLimit: 12` so the modernization sweep doesn't open 50 PRs at once
- New group: bjw-s `app-template` — bumps land as one fleet-wide PR for review

## Test plan

- [ ] Renovate dependency dashboard renders without warnings about deprecated config
- [ ] First PR after merge picks up at least one helm chart (e.g. `app-template`) — proves managers still match
- [ ] Existing `# renovate: datasource=…` comment in `kube-prometheus-stack/helmrelease.yaml` for Thanos still resolves to a `customManagers` match