### PR TITLE
fix(metallb): disable frr-k8s subchart for L2-only deployments

### DIFF
--- a/kubernetes/apps/networking/metallb/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/metallb/app/helmrelease.yaml
@@ -33,3 +33,10 @@ spec:
       # No frr/bgp needed.
       frr:
         enabled: false
+    # MetalLB 0.16 made frr-k8s the default BGP backend (frrk8s.enabled=true)
+    # and the chart unconditionally renders the frr-k8s subchart's
+    # ServiceMonitor template, which dereferences values that don't exist
+    # in our minimal config. Disable the whole subchart since L2 mode
+    # doesn't need any BGP backend.
+    frrk8s:
+      enabled: false


### PR DESCRIPTION
## Summary

Follow-up to #677. The MetalLB 0.16 chart bump merged cleanly, but Flux's Helm upgrade is timing out because the chart now renders the `frr-k8s` subchart unconditionally and that subchart's `ServiceMonitor` template dereferences a nil `prometheus.serviceMonitor`.

The 0.14.8 deployment is still serving all four LB IPs (`.200/.201/.202/.203`) — no traffic impact — but the upgrade can't complete until we tell the chart not to render the frr-k8s subchart.

## Why this happened

MetalLB 0.16 made `frrk8s` the default BGP backend (`frrk8s.enabled: true`). We don't use BGP at all (L2/ARP on the docker bridge), so the simplest fix is to disable the whole subchart.

## Test plan

- [ ] Helm upgrade succeeds and `kubectl -n networking get hr metallb -o jsonpath='{.status.history[0].chartVersion}'` reports `0.16.0`
- [ ] All four LoadBalancer Services keep their IPs (`.200/.201/.202/.203`) through the upgrade
- [ ] `metallb-speaker-*` pods are running on every node post-upgrade