### PR TITLE
chore(ms-01): sync CILIUM_VERSION to 1.19.4

### DIFF
--- a/kubernetes/clusters/ms-01/cluster-settings.yaml
+++ b/kubernetes/clusters/ms-01/cluster-settings.yaml
@@ -46,7 +46,7 @@ data:
   # CNI — Cilium with kube-proxy replacement, Hubble UI exposed via internal
   # ingress, ServiceMonitors on for kube-prometheus-stack scrape.
   CNI: "cilium"
-  CILIUM_VERSION: "1.17.16"
+  CILIUM_VERSION: "1.19.4"
   CILIUM_HUBBLE_UI_INGRESS_ENABLED: "true"
   CILIUM_SERVICEMONITOR_ENABLED: "true"
 


### PR DESCRIPTION
## Summary

Renovate PR #669 bumped the ansible cilium bootstrap template to 1.19.4. The in-tree Cilium HelmRelease pins via `${CILIUM_VERSION}` in `cluster-settings.yaml`, which Renovate can't touch. This brings the two in sync so when MS-01 bootstraps, the ansible-installed Cilium and the Flux-reconciled HR target the same chart version.

WSL is unaffected — Cilium isn't deployed there (Flannel CNI).

## Test plan

- [ ] No-op until MS-01 is bootstrapped (verified locally that no other manifests reference `CILIUM_VERSION` outside the HR)