### PR TITLE
fix(ingress-nginx): re-enable snippet annotations

### DIFF
--- a/kubernetes/apps/networking/ingress-nginx/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/ingress-nginx/app/helmrelease.yaml
@@ -50,6 +50,12 @@ spec:
         keep-alive-requests: 10000
         proxy-body-size: "100M"
         ssl-protocols: "TLSv1.3 TLSv1.2"
+        # ingress-nginx 1.9+ disables snippet annotations by default after
+        # CVE-2024-7646. We use server-snippet on ombi/sonarr/radarr for
+        # legacy hostname redirects; flip this back on rather than rip
+        # them out. Re-evaluate when those apps are reworked.
+        allow-snippet-annotations: "true"
+        annotations-risk-level: "Critical"
       metrics:
         enabled: ${SERVICE_MONITOR_ENABLED}
         serviceMonitor:


### PR DESCRIPTION
## Summary

- ingress-nginx 1.9+ disables `nginx.ingress.kubernetes.io/server-snippet` and `configuration-snippet` by default after CVE-2024-7646.
- After the chart 4.8.3 → 4.15.1 bump landed in #672, ombi's helm rollback failed because its ingress sets a `server-snippet` for a legacy `request.* → requests.*` redirect.
- Three apps in this repo use snippets: ombi, sonarr, radarr. Flipping `allow-snippet-annotations: true` + `annotations-risk-level: Critical` rather than ripping them out — re-evaluate when those apps are reworked.

## Test plan

- [ ] Flux reconciles `ingress-nginx` HelmRelease.
- [ ] `ombi` HR rolls forward (no longer stuck rolling back to v5).
- [ ] `requests.${SECRET_DOMAIN}` and `request.${SECRET_DOMAIN}` continue to serve.