### PR TITLE
fix(monitoring): label namespace pod-security=privileged

### DIFF
--- a/kubernetes/apps/monitoring/namespace.yaml
+++ b/kubernetes/apps/monitoring/namespace.yaml
@@ -5,3 +5,8 @@ metadata:
   name: monitoring
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # node-exporter and blackbox-exporter need hostPath/hostNetwork/hostPID,
+    # all forbidden under PSA baseline. Other pods in this namespace are
+    # not auto-elevated — PSA only enforces the upper bound.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest


### PR DESCRIPTION
## Summary
- node-exporter and blackbox-exporter require hostPath/hostPID/hostNetwork, blocked by PSA baseline (Talos cluster default).
- Adds `pod-security.kubernetes.io/enforce=privileged` to the monitoring namespace, matching networking/media/rook-ceph.

## Test plan
- [ ] flux kustomization reconciles cluster-apps without diffs elsewhere
- [ ] DaemonSet/node-exporter pods schedule on all nodes
- [ ] DaemonSet/blackbox-exporter (when its app-template migration lands) can schedule

Unblocks #659 (node-exporter chart 4.55).