### PR TITLE
fix(grafana): disable initChownData on WSL local-path PVC

### DIFF
--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -33,6 +33,12 @@ spec:
   values:
     deploymentStrategy:
       type: Recreate
+    # init-chown-data runs busybox chown as root over the PVC. On WSL
+    # local-path PVCs that EPERMs against existing files owned by the
+    # grafana uid (472), and the pod CrashLoops. Modern grafana sets
+    # its own ownership via fsGroup; we don't need the init container.
+    initChownData:
+      enabled: false
     admin:
       existingSecret: grafana-admin-secret
     env:


### PR DESCRIPTION
## Summary
- Grafana chart 10.x adds an init-chown-data busybox container that EPERMs against existing files on WSL local-path PVCs.
- Modern Grafana sets its own ownership via fsGroup; the init container is unnecessary.

Fix-forward for #1062.

## Test plan
- [ ] Pod transitions to Running on WSL after reconcile
- [ ] Existing dashboards/data preserved (PVC retained)