### PR TITLE
refactor: migrate 24 apps to bjw-s app-template 3.7.3

### DIFF
--- a/kubernetes/apps/default/echo-server/app/helmrelease.yaml
+++ b/kubernetes/apps/default/echo-server/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       sourceRef:
         kind: HelmRepository
         name: bjw-s
@@ -29,35 +29,44 @@ spec:
     - name: ingress-nginx
       namespace: networking
   values:
-    controller:
-      strategy: RollingUpdate
-    image:
-      repository: docker.io/jmalloc/echo-server
-      tag: v0.3.7
+    controllers:
+      echo-server:
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: docker.io/jmalloc/echo-server
+              tag: v0.3.7
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &port 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 5m
+                memory: 10Mi
+              limits:
+                memory: 50Mi
     service:
-      main:
+      app:
+        controller: echo-server
         ports:
           http:
-            port: &port 8080
-    probes:
-      liveness: &probes
-        enabled: true
-        custom: true
-        spec:
-          httpGet:
-            path: /health
             port: *port
-          initialDelaySeconds: 0
-          periodSeconds: 10
-          timeoutSeconds: 1
-          failureThreshold: 3
-      readiness: *probes
-      startup:
-        enabled: false
     ingress:
-      main:
-        enabled: true
-        ingressClassName: nginx
+      app:
+        className: nginx
         annotations:
           external-dns.alpha.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
           hajimari.io/icon: video-input-antenna
@@ -66,12 +75,9 @@ spec:
             paths:
               - path: /
                 pathType: Prefix
+                service:
+                  identifier: app
+                  port: http
         tls:
           - hosts:
               - *host
-    resources:
-      requests:
-        cpu: 5m
-        memory: 10Mi
-      limits:
-        memory: 50Mi

--- a/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       sourceRef:
         kind: HelmRepository
         name: bjw-s
@@ -27,60 +27,71 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    initContainers:
-      01-init-db:
-        image: ghcr.io/onedr0p/postgres-init:17.4
-        imagePullPolicy: IfNotPresent
-        envFrom: &envFrom
-          - secretRef:
-              name: home-assistant-secrets
-    controller:
-      type: statefulset
-      annotations:
-        reloader.stakater.com/auto: "true"
-    image:
-      repository: ghcr.io/onedr0p/home-assistant
-      tag: 2025.3.3@sha256:9e2a7177b4600653d6cb46dff01b1598189a5ae93be0b99242fbc039d32d79f1
-    env:
-      TZ: America/New_York
-      POSTGRES_HOST: ${POSTGRES_SERVER}
-      POSTGRES_DB: home_assistant
-    envFrom: *envFrom
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      home-assistant:
+        type: statefulset
+        annotations:
+          reloader.stakater.com/auto: "true"
+        statefulset:
+          volumeClaimTemplates:
+            - name: config
+              accessMode: ReadWriteOnce
+              size: 5Gi
+              storageClass: "${STORAGE_CLASS_DEFAULT}"
+              globalMounts:
+                - path: /config
+        initContainers:
+          01-init-db:
+            image:
+              repository: ghcr.io/onedr0p/postgres-init
+              tag: "17.4"
+              pullPolicy: IfNotPresent
+            envFrom: &envFrom
+              - secretRef:
+                  name: home-assistant-secrets
+        containers:
+          app:
+            image:
+              repository: ghcr.io/onedr0p/home-assistant
+              tag: 2025.3.3@sha256:9e2a7177b4600653d6cb46dff01b1598189a5ae93be0b99242fbc039d32d79f1
+            env:
+              TZ: America/New_York
+              POSTGRES_HOST: ${POSTGRES_SERVER}
+              POSTGRES_DB: home_assistant
+            envFrom: *envFrom
+            probes:
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 10m
+                memory: 100Mi
+              limits:
+                memory: 750Mi
     service:
-      main:
+      app:
+        controller: home-assistant
         ports:
           http:
             port: 8123
     ingress:
-      main:
-        enabled: true
-        ingressClassName: nginx-internal
+      app:
+        className: nginx-internal
         hosts:
           - host: &host hass.${INTERNAL_DOMAIN}
             paths:
               - path: /
                 pathType: Prefix
-    probes:
-      liveness:
-        enabled: false
-      readiness:
-        enabled: false
-      startup:
-        enabled: false
-    podSecurityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
-      fsGroupChangePolicy: OnRootMismatch
-    volumeClaimTemplates:
-      - name: config
-        mountPath: /config
-        accessMode: ReadWriteOnce
-        size: 5Gi
-        storageClass: "${STORAGE_CLASS_DEFAULT}"
-    resources:
-      requests:
-        cpu: 10m
-        memory: 100Mi
-      limits:
-        memory: 750Mi
+                service:
+                  identifier: app
+                  port: http

--- a/kubernetes/apps/home-automation/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mosquitto/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 2.4.0
+      version: 3.7.3
       sourceRef:
         kind: HelmRepository
         name: bjw-s
@@ -24,8 +24,15 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        runAsNonRoot: true
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
     controllers:
-      main:
+      mosquitto:
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:
@@ -36,7 +43,7 @@ spec:
             command: ["/bin/sh", "-c"]
             args: ["cp /tmp/secret/* /mosquitto/external_config/ && mosquitto_passwd -U /mosquitto/external_config/mosquitto_pwd"]
         containers:
-          main:
+          app:
             image:
               repository: docker.io/library/eclipse-mosquitto
               tag: 2.0.22@sha256:914f529386804c8278a4e581526b9be5e1604df44b30daabc70aa97dcefe5268
@@ -49,15 +56,9 @@ spec:
                 cpu: 10m
               limits:
                 memory: 16Mi
-        pod:
-          securityContext:
-            runAsUser: 568
-            runAsGroup: 568
-            runAsNonRoot: true
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
     service:
-      main:
+      app:
+        controller: mosquitto
         type: LoadBalancer
         loadBalancerIP: "${MQTT_LB_ADDR}"
         ports:
@@ -65,7 +66,6 @@ spec:
             port: 1883
     persistence:
       config:
-        enabled: true
         accessMode: ReadWriteOnce
         size: 1Gi
         storageClass: "${STORAGE_CLASS_DEFAULT}"
@@ -75,15 +75,15 @@ spec:
         type: configMap
         name: mosquitto-configmap
         advancedMounts:
-          main:
-            main:
+          mosquitto:
+            app:
               - path: /mosquitto/config/mosquitto.conf
                 subPath: mosquitto.conf
       secret-file:
         type: secret
         name: mosquitto-secrets
         advancedMounts:
-          main:
+          mosquitto:
             init-config:
               - path: /tmp/secret
       external-config:

--- a/kubernetes/apps/home-automation/peloton-to-garmin/app-it/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/peloton-to-garmin/app-it/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       sourceRef:
         kind: HelmRepository
         name: bjw-s
@@ -25,94 +25,75 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
-
   values:
-    image:
-      repository: ghcr.io/philosowaffle/peloton-to-garmin
-      pullPolicy: IfNotPresent
-      tag: v3.6.1
-
-    strategy:
-      type: Recreate
-
-    envFrom:
-      - secretRef:
-          name: peloton-to-garmin-it-secrets
-
-    env:
-      - name: TZ
-        value: America/Los_Angeles
-      - name: P2G_APP__POLLINGINTERVALSECONDS
-        value: 7200
-      - name: P2G_APP__CHECKFORUPDATES
-        value: false
-      - name: P2G_PELOTON__NUMWORKOUTSTODOWNLOAD
-        value: 8
-      - name: P2G_GARMIN__UPLOAD
-        value: true
-        #https://philosowaffle.github.io/peloton-to-garmin/configuration/json.html#upload-strategies
-      - name: P2G_GARMIN__UPLOADSTRATEGY
-        value: 2
-      - name: P2G_OBSERVABILITY__PROMETHEUS__ENABLED
-        value: true
-      - name: P2G_OBSERVABILITY__PROMETHEUS__PORT
-        value: 4000
-
-      - name: P2G_PELOTON__EMAIL
-        valueFrom:
-          secretKeyRef:
-            name: peloton-to-garmin-it-secrets
-            key: P2G_PELOTON__EMAIL
-
-      - name: P2G_PELOTON__PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: peloton-to-garmin-it-secrets
-            key: P2G_PELOTON__PASSWORD
-
-      - name: P2G_GARMIN__EMAIL
-        valueFrom:
-          secretKeyRef:
-            name: peloton-to-garmin-it-secrets
-            key: P2G_GARMIN__EMAIL
-
-      - name: P2G_GARMIN__PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: peloton-to-garmin-it-secrets
-            key: P2G_GARMIN__PASSWORD
-
+    controllers:
+      peloton-to-garmin-it:
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/philosowaffle/peloton-to-garmin
+              pullPolicy: IfNotPresent
+              tag: v3.6.1
+            envFrom:
+              - secretRef:
+                  name: peloton-to-garmin-it-secrets
+            env:
+              - name: TZ
+                value: America/Los_Angeles
+              - name: P2G_APP__POLLINGINTERVALSECONDS
+                value: "7200"
+              - name: P2G_APP__CHECKFORUPDATES
+                value: "false"
+              - name: P2G_PELOTON__NUMWORKOUTSTODOWNLOAD
+                value: "8"
+              - name: P2G_GARMIN__UPLOAD
+                value: "true"
+                #https://philosowaffle.github.io/peloton-to-garmin/configuration/json.html#upload-strategies
+              - name: P2G_GARMIN__UPLOADSTRATEGY
+                value: "2"
+              - name: P2G_OBSERVABILITY__PROMETHEUS__ENABLED
+                value: "true"
+              - name: P2G_OBSERVABILITY__PROMETHEUS__PORT
+                value: "4000"
+              - name: P2G_PELOTON__EMAIL
+                valueFrom:
+                  secretKeyRef:
+                    name: peloton-to-garmin-it-secrets
+                    key: P2G_PELOTON__EMAIL
+              - name: P2G_PELOTON__PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: peloton-to-garmin-it-secrets
+                    key: P2G_PELOTON__PASSWORD
+              - name: P2G_GARMIN__EMAIL
+                valueFrom:
+                  secretKeyRef:
+                    name: peloton-to-garmin-it-secrets
+                    key: P2G_GARMIN__EMAIL
+              - name: P2G_GARMIN__PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: peloton-to-garmin-it-secrets
+                    key: P2G_GARMIN__PASSWORD
+            probes:
+              startup:
+                enabled: false
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
     service:
-      main:
+      app:
+        controller: peloton-to-garmin-it
         ports:
           http:
             port: 80
-
-    probes:
-      startup:
-        enabled: false
-      liveness:
-        enabled: false
-      readiness:
-        enabled: false
-    # ingress:
-    #   main:
-    #     enabled: true
-    #     ingressClassName: nginx
-    #     annotations:
-    #       external-dns.alpha.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
-    #     hosts:
-    #       - host: &host "bookstack.${SECRET_DOMAIN}"
-    #         paths:
-    #           - path: /
-    #             pathType: Prefix
-    #     tls:
-    #       - hosts:
-    #           - *host
-
     persistence:
       config:
         enabled: true
         accessMode: ReadWriteOnce
         size: 1Gi
         storageClass: "${STORAGE_CLASS_DEFAULT}"
+        globalMounts:
+          - path: /config

--- a/kubernetes/apps/home-automation/peloton-to-garmin/app-mh/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/peloton-to-garmin/app-mh/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       sourceRef:
         kind: HelmRepository
         name: bjw-s
@@ -25,94 +25,75 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
-
   values:
-    image:
-      repository: ghcr.io/philosowaffle/peloton-to-garmin
-      pullPolicy: IfNotPresent
-      tag: v3.6.1
-
-    strategy:
-      type: Recreate
-
-    envFrom:
-      - secretRef:
-          name: peloton-to-garmin-mh-secrets
-
-    env:
-      - name: TZ
-        value: America/Los_Angeles
-      - name: P2G_APP__POLLINGINTERVALSECONDS
-        value: 7200
-      - name: P2G_APP__CHECKFORUPDATES
-        value: false
-      - name: P2G_PELOTON__NUMWORKOUTSTODOWNLOAD
-        value: 8
-      - name: P2G_GARMIN__UPLOAD
-        value: true
-        #https://philosowaffle.github.io/peloton-to-garmin/configuration/json.html#upload-strategies
-      - name: P2G_GARMIN__UPLOADSTRATEGY
-        value: 2
-      - name: P2G_OBSERVABILITY__PROMETHEUS__ENABLED
-        value: true
-      - name: P2G_OBSERVABILITY__PROMETHEUS__PORT
-        value: 4000
-
-      - name: P2G_PELOTON__EMAIL
-        valueFrom:
-          secretKeyRef:
-            name: peloton-to-garmin-it-secrets
-            key: P2G_PELOTON__EMAIL
-
-      - name: P2G_PELOTON__PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: peloton-to-garmin-it-secrets
-            key: P2G_PELOTON__PASSWORD
-
-      - name: P2G_GARMIN__EMAIL
-        valueFrom:
-          secretKeyRef:
-            name: peloton-to-garmin-it-secrets
-            key: P2G_GARMIN__EMAIL
-
-      - name: P2G_GARMIN__PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: peloton-to-garmin-it-secrets
-            key: P2G_GARMIN__PASSWORD
-
+    controllers:
+      peloton-to-garmin-mh:
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/philosowaffle/peloton-to-garmin
+              pullPolicy: IfNotPresent
+              tag: v3.6.1
+            envFrom:
+              - secretRef:
+                  name: peloton-to-garmin-mh-secrets
+            env:
+              - name: TZ
+                value: America/Los_Angeles
+              - name: P2G_APP__POLLINGINTERVALSECONDS
+                value: "7200"
+              - name: P2G_APP__CHECKFORUPDATES
+                value: "false"
+              - name: P2G_PELOTON__NUMWORKOUTSTODOWNLOAD
+                value: "8"
+              - name: P2G_GARMIN__UPLOAD
+                value: "true"
+                #https://philosowaffle.github.io/peloton-to-garmin/configuration/json.html#upload-strategies
+              - name: P2G_GARMIN__UPLOADSTRATEGY
+                value: "2"
+              - name: P2G_OBSERVABILITY__PROMETHEUS__ENABLED
+                value: "true"
+              - name: P2G_OBSERVABILITY__PROMETHEUS__PORT
+                value: "4000"
+              - name: P2G_PELOTON__EMAIL
+                valueFrom:
+                  secretKeyRef:
+                    name: peloton-to-garmin-it-secrets
+                    key: P2G_PELOTON__EMAIL
+              - name: P2G_PELOTON__PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: peloton-to-garmin-it-secrets
+                    key: P2G_PELOTON__PASSWORD
+              - name: P2G_GARMIN__EMAIL
+                valueFrom:
+                  secretKeyRef:
+                    name: peloton-to-garmin-it-secrets
+                    key: P2G_GARMIN__EMAIL
+              - name: P2G_GARMIN__PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: peloton-to-garmin-it-secrets
+                    key: P2G_GARMIN__PASSWORD
+            probes:
+              startup:
+                enabled: false
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
     service:
-      main:
+      app:
+        controller: peloton-to-garmin-mh
         ports:
           http:
             port: 80
-
-    probes:
-      startup:
-        enabled: false
-      liveness:
-        enabled: false
-      readiness:
-        enabled: false
-    # ingress:
-    #   main:
-    #     enabled: true
-    #     ingressClassName: nginx
-    #     annotations:
-    #       external-dns.alpha.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
-    #     hosts:
-    #       - host: &host "bookstack.${SECRET_DOMAIN}"
-    #         paths:
-    #           - path: /
-    #             pathType: Prefix
-    #     tls:
-    #       - hosts:
-    #           - *host
-
     persistence:
       config:
         enabled: true
         accessMode: ReadWriteOnce
         size: 1Gi
         storageClass: "${STORAGE_CLASS_DEFAULT}"
+        globalMounts:
+          - path: /config

--- a/kubernetes/apps/home-automation/zwave-js-ui/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/zwave-js-ui/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       sourceRef:
         kind: HelmRepository
         name: bjw-s
@@ -27,67 +27,73 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    controller:
-      type: statefulset
-    image:
-      repository: ghcr.io/zwave-js/zwave-js-ui
-      tag: 9.3.2
-    env:
-      TZ: ${TIMEZONE}
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: "sce-uk8sw03"
+    controllers:
+      zwave-js-ui:
+        type: statefulset
+        statefulset:
+          volumeClaimTemplates:
+            - name: config
+              accessMode: ReadWriteOnce
+              size: 1Gi
+              storageClass: "${STORAGE_CLASS_DEFAULT}"
+              globalMounts:
+                - path: /usr/src/app/store
+        containers:
+          app:
+            image:
+              repository: ghcr.io/zwave-js/zwave-js-ui
+              tag: 9.3.2
+            env:
+              TZ: ${TIMEZONE}
+            securityContext:
+              privileged: true
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &port 8091
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 10m
+                memory: 100Mi
+              limits:
+                memory: 500Mi
     service:
-      main:
+      app:
+        controller: zwave-js-ui
         ports:
           http:
-            port: &port 8091
-          websocket:
-            enabled: true
-            port: 3000
-    # serviceMonitor:
-    #   main:
-    #     enabled: true
-    probes:
-      liveness: &probes
-        enabled: true
-        custom: true
-        spec:
-          httpGet:
-            path: /health
             port: *port
-          initialDelaySeconds: 0
-          periodSeconds: 10
-          timeoutSeconds: 1
-          failureThreshold: 3
-      readiness: *probes
-      startup:
-        enabled: false
+          websocket:
+            port: 3000
+    persistence:
+      usb:
+        type: hostPath
+        hostPath: /dev/serial/by-id/usb-0658_0200-if00  #had to configure this serial port in settings manually via browser
+        hostPathType: CharDevice
+        globalMounts:
+          - path: /dev/serial/by-id/usb-0658_0200-if00
     ingress:
-      main:
-        enabled: true
-        ingressClassName: nginx-internal
+      app:
+        className: nginx-internal
         hosts:
           - host: &host "zwave.${INTERNAL_DOMAIN}"
             paths:
               - path: /
                 pathType: Prefix
-    securityContext:
-      privileged: true
-    volumeClaimTemplates:
-      - name: config
-        mountPath: /usr/src/app/store
-        accessMode: ReadWriteOnce
-        size: 1Gi
-        storageClass: "${STORAGE_CLASS_DEFAULT}"
-    persistence:
-      usb:
-        enabled: true
-        type: hostPath
-        hostPath: /dev/serial/by-id/usb-0658_0200-if00  #had to configure this serial port in settings manually via browser
-        hostPathType: CharDevice
-    nodeSelector:
-      kubernetes.io/hostname: "sce-uk8sw03"
-    resources:
-      requests:
-        cpu: 10m
-        memory: 100Mi
-      limits:
-        memory: 500Mi
+                service:
+                  identifier: app
+                  port: http

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -9,60 +9,55 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       interval: 30m
       sourceRef:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-
   values:
-    controller:
-      annotations:
-        reloader.stakater.com/auto: "true"
-
-    image:
-      repository: ghcr.io/onedr0p/prowlarr-develop
-      tag: 1.32.2.4987@sha256:f3c0edbd19d744c8306ae8f72e75f0fb54ff662e9f7b22a4d9029e5c0b7f075c
-
-    podAnnotations:
-      setGateway: "true"
-
-    podSecurityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
-      fsGroupChangePolicy: "OnRootMismatch"
-
-    env:
-      PROWLARR__INSTANCE_NAME: Prowlarr
-      PROWLARR__PORT: &port 9696
-      PROWLARR__LOG_LEVEL: info
-      PROWLARR__ANALYTICS_ENABLED: "False"
-      PROWLARR__AUTHENTICATION_METHOD: External
-      PROWLARR__API_KEY:
-        valueFrom:
-          secretKeyRef:
-            name: prowlarr-secret
-            key: API_KEY
-
-    hostname: prowlarr
-
+    defaultPodOptions:
+      hostname: prowlarr
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: "OnRootMismatch"
+    controllers:
+      prowlarr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          annotations:
+            setGateway: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/onedr0p/prowlarr-develop
+              tag: 1.32.2.4987@sha256:f3c0edbd19d744c8306ae8f72e75f0fb54ff662e9f7b22a4d9029e5c0b7f075c
+            env:
+              PROWLARR__INSTANCE_NAME: Prowlarr
+              PROWLARR__PORT: &port 9696
+              PROWLARR__LOG_LEVEL: info
+              PROWLARR__ANALYTICS_ENABLED: "False"
+              PROWLARR__AUTHENTICATION_METHOD: External
+              PROWLARR__API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: prowlarr-secret
+                    key: API_KEY
+            resources:
+              requests:
+                cpu: 18m
+                memory: 160Mi
+              limits:
+                memory: 160Mi
     service:
-      main:
+      app:
+        controller: prowlarr
         ports:
           http:
             port: *port
-
-    ingress:
-      internal:
-        enabled: true
-        ingressClassName: "nginx"
-        hosts:
-          - host: &internalHost "prowlarr.${INTERNAL_DOMAIN}"
-            paths:
-              - path: /
-
     persistence:
       config:
         enabled: true
@@ -70,10 +65,16 @@ spec:
         size: 1Gi
         storageClass: ${STORAGE_CLASS_DEFAULT}
         retain: true
-
-    resources:
-      requests:
-        cpu: 18m
-        memory: 160Mi
-      limits:
-        memory: 160Mi
+        globalMounts:
+          - path: /config
+    ingress:
+      internal:
+        className: nginx
+        hosts:
+          - host: &internalHost "prowlarr.${INTERNAL_DOMAIN}"
+            paths:
+              - path: /
+                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -9,164 +9,169 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       interval: 30m
       sourceRef:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-
   values:
-    controller:
-      type: statefulset
-      annotations:
-        reloader.stakater.com/auto: "true"
-
-    image:
-      repository: ghcr.io/onedr0p/qbittorrent
-      tag: 4.6.7@sha256:5391f94b321d563c3b44136a5e799b7e4e4888926c1c31d3081a1cf3e74a9aec
-
-    podSecurityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
-      fsGroupChangePolicy: "OnRootMismatch"
-      supplementalGroups:
-        - 65539
-
-    initContainers:
-      copy-config:
-        # No env-var substitution is needed in the bundled config files,
-        # so a plain busybox `cp` is sufficient. The previous
-        # ghcr.io/onedr0p/alpine image was GC'd from ghcr.
-        image: public.ecr.aws/docker/library/busybox:1.38.0
-        command:
-          - "/bin/sh"
-          - -c
-        args:
-          - cp /data/configfiles/* /data/config/
-        volumeMounts:
-          - name: config
-            mountPath: /data/config
-          - name: configfiles
-            mountPath: /data/configfiles
-
-    # gluetun sidecar holds the iVPN WireGuard tunnel. qbittorrent shares the
-    # pod's network namespace; all its traffic is forced through the tunnel.
-    # If gluetun's tunnel drops, qbittorrent loses network — fail-closed.
-    additionalContainers:
-      gluetun:
-        image: ghcr.io/qdm12/gluetun:v3.41.1
-        securityContext:
-          # gluetun manages iptables + creates the wg0 interface; needs to
-          # run as root with NET_ADMIN. The pod-level podSecurityContext
-          # forces uid 568, so explicitly override here.
-          runAsUser: 0
-          runAsGroup: 0
-          capabilities:
-            add: ["NET_ADMIN"]
-        env:
-          - name: VPN_SERVICE_PROVIDER
-            value: ivpn
-          - name: VPN_TYPE
-            value: wireguard
-          - name: WIREGUARD_PRIVATE_KEY
-            valueFrom:
-              secretKeyRef:
-                name: qbittorrent-vpn-secret
-                key: WIREGUARD_PRIVATE_KEY
-          - name: WIREGUARD_PUBLIC_KEY
-            valueFrom:
-              secretKeyRef:
-                name: qbittorrent-vpn-secret
-                key: WIREGUARD_PUBLIC_KEY
-          - name: WIREGUARD_PRESHARED_KEY
-            valueFrom:
-              secretKeyRef:
-                name: qbittorrent-vpn-secret
-                key: WIREGUARD_PRESHARED_KEY
-                optional: true
-          - name: WIREGUARD_ADDRESSES
-            valueFrom:
-              secretKeyRef:
-                name: qbittorrent-vpn-secret
-                key: WIREGUARD_ADDRESSES
-          - name: WIREGUARD_ENDPOINT_IP
-            valueFrom:
-              secretKeyRef:
-                name: qbittorrent-vpn-secret
-                key: WIREGUARD_ENDPOINT_IP
-          - name: WIREGUARD_ENDPOINT_PORT
-            valueFrom:
-              secretKeyRef:
-                name: qbittorrent-vpn-secret
-                key: WIREGUARD_ENDPOINT_PORT
-                optional: true
-          - name: SERVER_COUNTRIES
-            value: "" # leave empty when WIREGUARD_ENDPOINT_IP is set
-          - name: TZ
-            value: "${TIMEZONE}"
-          - name: FIREWALL_INPUT_PORTS
-            # qbittorrent webUI port must be reachable from the cluster network
-            # so the Service / Ingress can forward to it.
-            value: "8080"
-          - name: HEALTH_VPN_DURATION_INITIAL
-            value: "30s"
-
-    env:
-      UMASK: "022"
-      QBITTORRENT__PORT: &port 8080
-      QBITTORRENT__USE_PROFILE: "true"
-
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: "OnRootMismatch"
+        supplementalGroups:
+          - 65539
+    controllers:
+      qbittorrent:
+        type: statefulset
+        annotations:
+          reloader.stakater.com/auto: "true"
+        statefulset:
+          volumeClaimTemplates:
+            - name: data
+              accessMode: ReadWriteOnce
+              size: 1Gi
+              storageClass: ${STORAGE_CLASS_DEFAULT}
+              globalMounts:
+                - path: /config/qBittorrent/data
+        initContainers:
+          copy-config:
+            # No env-var substitution is needed in the bundled config files,
+            # so a plain busybox `cp` is sufficient. The previous
+            # ghcr.io/onedr0p/alpine image was GC'd from ghcr.
+            image:
+              repository: public.ecr.aws/docker/library/busybox
+              tag: "1.38.0"
+            command:
+              - "/bin/sh"
+              - -c
+            args:
+              - cp /data/configfiles/* /data/config/
+        containers:
+          app:
+            image:
+              repository: ghcr.io/onedr0p/qbittorrent
+              tag: 4.6.7@sha256:5391f94b321d563c3b44136a5e799b7e4e4888926c1c31d3081a1cf3e74a9aec
+            env:
+              UMASK: "022"
+              QBITTORRENT__PORT: &port 8080
+              QBITTORRENT__USE_PROFILE: "true"
+            resources:
+              requests:
+                cpu: 49m
+                memory: 1222Mi
+              limits:
+                memory: 1222Mi
+          # gluetun sidecar holds the iVPN WireGuard tunnel. qbittorrent shares the
+          # pod's network namespace; all its traffic is forced through the tunnel.
+          # If gluetun's tunnel drops, qbittorrent loses network — fail-closed.
+          gluetun:
+            image:
+              repository: ghcr.io/qdm12/gluetun
+              tag: v3.41.1
+            securityContext:
+              # gluetun manages iptables + creates the wg0 interface; needs to
+              # run as root with NET_ADMIN. The pod-level securityContext
+              # forces uid 568, so explicitly override here.
+              runAsUser: 0
+              runAsGroup: 0
+              capabilities:
+                add: ["NET_ADMIN"]
+            env:
+              - name: VPN_SERVICE_PROVIDER
+                value: ivpn
+              - name: VPN_TYPE
+                value: wireguard
+              - name: WIREGUARD_PRIVATE_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: qbittorrent-vpn-secret
+                    key: WIREGUARD_PRIVATE_KEY
+              - name: WIREGUARD_PUBLIC_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: qbittorrent-vpn-secret
+                    key: WIREGUARD_PUBLIC_KEY
+              - name: WIREGUARD_PRESHARED_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: qbittorrent-vpn-secret
+                    key: WIREGUARD_PRESHARED_KEY
+              - name: WIREGUARD_ADDRESSES
+                valueFrom:
+                  secretKeyRef:
+                    name: qbittorrent-vpn-secret
+                    key: WIREGUARD_ADDRESSES
+              - name: WIREGUARD_ENDPOINT_IP
+                valueFrom:
+                  secretKeyRef:
+                    name: qbittorrent-vpn-secret
+                    key: WIREGUARD_ENDPOINT_IP
+              - name: WIREGUARD_ENDPOINT_PORT
+                valueFrom:
+                  secretKeyRef:
+                    name: qbittorrent-vpn-secret
+                    key: WIREGUARD_ENDPOINT_PORT
+              - name: SERVER_COUNTRIES
+                value: "" # leave empty when WIREGUARD_ENDPOINT_IP is set
+              - name: TZ
+                value: "${TIMEZONE}"
+              - name: FIREWALL_INPUT_PORTS
+                # qbittorrent webUI port must be reachable from the cluster network
+                # so the Service / Ingress can forward to it.
+                value: "8080"
+              - name: HEALTH_VPN_DURATION_INITIAL
+                value: "30s"
     service:
-      main:
+      app:
+        controller: qbittorrent
         ports:
           http:
             port: *port
-
+    persistence:
+      config:
+        type: emptyDir
+        advancedMounts:
+          qbittorrent:
+            app:
+              - path: /config/qBittorrent/config
+      cache:
+        type: emptyDir
+        advancedMounts:
+          qbittorrent:
+            app:
+              - path: /config/qBittorrent/cache
+      configfiles:
+        type: configMap
+        name: qbittorrent-configmap
+        advancedMounts:
+          qbittorrent:
+            copy-config:
+              - path: /data/configfiles
+            app: []
+      config-target:
+        type: emptyDir
+        advancedMounts:
+          qbittorrent:
+            copy-config:
+              - path: /data/config
+      media:
+        existingClaim: cephfs-hdd-subvolume-qbit
+        globalMounts:
+          - path: /data/media
     ingress:
       internal:
-        enabled: true
         # Internal-only — qbittorrent webUI must NEVER be exposed publicly.
         # The traffic itself egresses through the gluetun sidecar.
-        ingressClassName: "nginx-internal"
+        className: nginx-internal
         hosts:
           - host: &internalHost "qbittorrent.${INTERNAL_DOMAIN}"
             paths:
               - path: /
-
-    persistence:
-      config:
-        enabled: true
-        type: emptyDir
-        mountPath: /config/qBittorrent/config
-
-      cache:
-        enabled: true
-        type: emptyDir
-        mountPath: /config/qBittorrent/cache
-
-      configfiles:
-        enabled: true
-        type: configMap
-        name: qbittorrent-configmap
-        mountPath: "-"
-
-      media:
-        enabled: true
-        existingClaim: cephfs-hdd-subvolume-qbit
-        mountPath: /data/media
-
-    resources:
-      requests:
-        cpu: 49m
-        memory: 1222Mi
-      limits:
-        memory: 1222Mi
-
-    volumeClaimTemplates:
-      - name: data
-        mountPath: /config/qBittorrent/data
-        accessMode: ReadWriteOnce
-        size: 1Gi
-        storageClass: ${STORAGE_CLASS_DEFAULT}
+                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -9,59 +9,72 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       interval: 30m
       sourceRef:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-
   values:
-    controller:
-      annotations:
-        reloader.stakater.com/auto: "true"
-
-    image:
-      repository: ghcr.io/onedr0p/radarr-develop
-      tag: 5.20.1.9773@sha256:8187c129a78fdfe15b1603db9175abd2be0e1ca2e99ea3733987c3ae941da165
-
-    # podAnnotations:
-    #   setGateway: "true"
-
-    podSecurityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
-      fsGroupChangePolicy: "OnRootMismatch"
-      supplementalGroups:
-        - 65539
-
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-    env:
-      RADARR__INSTANCE_NAME: Radarr
-      RADARR__PORT: &port 7878
-      RADARR__APPLICATION_URL: "https://radarr.${SECRET_DOMAIN}"
-      RADARR__LOG_LEVEL: info
-      RADARR__API_KEY:
-        valueFrom:
-          secretKeyRef:
-            name: radarr-secret
-            key: API_KEY
-
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: "OnRootMismatch"
+        supplementalGroups:
+          - 65539
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+    controllers:
+      radarr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/onedr0p/radarr-develop
+              tag: 5.20.1.9773@sha256:8187c129a78fdfe15b1603db9175abd2be0e1ca2e99ea3733987c3ae941da165
+            env:
+              RADARR__INSTANCE_NAME: Radarr
+              RADARR__PORT: &port 7878
+              RADARR__APPLICATION_URL: "https://radarr.${SECRET_DOMAIN}"
+              RADARR__LOG_LEVEL: info
+              RADARR__API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: radarr-secret
+                    key: API_KEY
+            resources:
+              requests:
+                cpu: 14m
+                memory: 431M
+              limits:
+                memory: 431M
     service:
-      main:
+      app:
+        controller: radarr
         ports:
           http:
             port: *port
-
+    persistence:
+      config:
+        enabled: true
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        storageClass: ${STORAGE_CLASS_DEFAULT}
+        retain: true
+        globalMounts:
+          - path: /config
+      media:
+        existingClaim: cephfs-hdd-subvolume-qbit
+        globalMounts:
+          - path: /data/media
     ingress:
       internal:
-        enabled: true
-        ingressClassName: "nginx"
+        className: nginx
         annotations:
           nginx.ingress.kubernetes.io/configuration-snippet: |
             proxy_set_header Accept-Encoding "";
@@ -70,32 +83,7 @@ spec:
           - host: &internalHost "radarr.${INTERNAL_DOMAIN}"
             paths:
               - path: /
-
-    existingClaim:
-
-    persistence:
-      config:
-        enabled: true
-        accessMode: ReadWriteOnce
-        size: 1Gi
-        storageClass: ${STORAGE_CLASS_DEFAULT}
-        retain: true
-
-      media:
-        enabled: true
-        existingClaim: cephfs-hdd-subvolume-qbit
-        mountPath: /data/media
-
-      # media:
-      #   enabled: true
-      #   type: nfs
-      #   server: "nas.bjw-s.tech"
-      #   path: /volume1/Media
-      #   mountPath: /data/media
-
-    resources:
-      requests:
-        cpu: 14m
-        memory: 431M
-      limits:
-        memory: 431M
+                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http

--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -9,70 +9,62 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       interval: 30m
       sourceRef:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-
   values:
-    controller:
-      type: statefulset
-      annotations:
-        reloader.stakater.com/auto: "true"
-
-    initContainers:
-      01-init-config:
-        image: public.ecr.aws/docker/library/busybox:latest@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
-        imagePullPolicy: IfNotPresent
-        command:
-          - "/bin/sh"
-          - "-c"
-          - "cp /tmp/config/recyclarr.yml /config/recyclarr.yml"
-        volumeMounts:
-          - name: config-file
-            mountPath: /tmp/config
-          - name: config
-            mountPath: /config
-
-    restartPolicy: OnFailure
-
-    image:
-      repository: ghcr.io/recyclarr/recyclarr
-      tag: 8.6.0
-
-    envFrom:
-      - secretRef:
-          name: recyclarr-secret
-
+    defaultPodOptions:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      recyclarr:
+        type: statefulset
+        annotations:
+          reloader.stakater.com/auto: "true"
+        statefulset:
+          volumeClaimTemplates:
+            - name: config
+              accessMode: ReadWriteOnce
+              size: 1Gi
+              storageClass: ${STORAGE_CLASS_DEFAULT}
+              globalMounts:
+                - path: /config
+        initContainers:
+          01-init-config:
+            image:
+              repository: public.ecr.aws/docker/library/busybox
+              tag: latest@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
+              pullPolicy: IfNotPresent
+            command:
+              - "/bin/sh"
+              - "-c"
+              - "cp /tmp/config/recyclarr.yml /config/recyclarr.yml"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/recyclarr/recyclarr
+              tag: 8.6.0
+            envFrom:
+              - secretRef:
+                  name: recyclarr-secret
+            resources:
+              requests:
+                cpu: 5m
+                memory: 360M
+              limits:
+                memory: 360M
     persistence:
       config-file:
-        enabled: true
         type: configMap
         name: recyclarr-configmap
-        mountPath: "-"
-
-    podSecurityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
-      fsGroupChangePolicy: OnRootMismatch
-
-    resources:
-      requests:
-        cpu: 5m
-        memory: 360M
-      limits:
-        memory: 360M
-
-    service:
-      main:
-        enabled: false
-
-    volumeClaimTemplates:
-      - name: config
-        mountPath: /config
-        accessMode: ReadWriteOnce
-        size: 1Gi
-        storageClass: ${STORAGE_CLASS_DEFAULT}
+        advancedMounts:
+          recyclarr:
+            01-init-config:
+              - path: /tmp/config

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -9,54 +9,68 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       interval: 30m
       sourceRef:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-
   values:
-    controller:
-      annotations:
-        reloader.stakater.com/auto: "true"
-
-    image:
-      repository: ghcr.io/onedr0p/sonarr-develop
-      tag: 4.0.14.2938@sha256:75da01d2da78d226cd89352fbab919f2eb26ea9a8d6c592bf812dde5f8949243
-
-    # podAnnotations:
-    #   setGateway: "true"
-
-    podSecurityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
-      fsGroupChangePolicy: "OnRootMismatch"
-      supplementalGroups:
-        - 65539
-
-    env:
-      SONARR__INSTANCE_NAME: Sonarr
-      SONARR__PORT: &port 8989
-      SONARR__APPLICATION_URL: "https://sonarr.${INTERNAL_DOMAIN}"
-      SONARR__LOG_LEVEL: info
-      SONARR__API_KEY:
-        valueFrom:
-          secretKeyRef:
-            name: sonarr-secret
-            key: API_KEY
-
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: "OnRootMismatch"
+        supplementalGroups:
+          - 65539
+    controllers:
+      sonarr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/onedr0p/sonarr-develop
+              tag: 4.0.14.2938@sha256:75da01d2da78d226cd89352fbab919f2eb26ea9a8d6c592bf812dde5f8949243
+            env:
+              SONARR__INSTANCE_NAME: Sonarr
+              SONARR__PORT: &port 8989
+              SONARR__APPLICATION_URL: "https://sonarr.${INTERNAL_DOMAIN}"
+              SONARR__LOG_LEVEL: info
+              SONARR__API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: sonarr-secret
+                    key: API_KEY
+            resources:
+              requests:
+                cpu: 20m
+                memory: 323M
+              limits:
+                memory: 323M
     service:
-      main:
+      app:
+        controller: sonarr
         ports:
           http:
             port: *port
-
+    persistence:
+      config:
+        enabled: true
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        storageClass: ${STORAGE_CLASS_DEFAULT}
+        retain: true
+        globalMounts:
+          - path: /config
+      media:
+        existingClaim: cephfs-hdd-subvolume-qbit
+        globalMounts:
+          - path: /data/media
     ingress:
       internal:
-        enabled: true
-        ingressClassName: "nginx"
+        className: nginx
         annotations:
           nginx.ingress.kubernetes.io/configuration-snippet: |
             proxy_set_header Accept-Encoding "";
@@ -65,23 +79,7 @@ spec:
           - host: &internalHost "sonarr.${INTERNAL_DOMAIN}"
             paths:
               - path: /
-
-    persistence:
-      config:
-        enabled: true
-        accessMode: ReadWriteOnce
-        size: 1Gi
-        storageClass: ${STORAGE_CLASS_DEFAULT}
-        retain: true
-
-      media:
-        enabled: true
-        existingClaim: cephfs-hdd-subvolume-qbit
-        mountPath: /data/media
-
-    resources:
-      requests:
-        cpu: 20m
-        memory: 323M
-      limits:
-        memory: 323M
+                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http

--- a/kubernetes/apps/monitoring/alertmanager/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/alertmanager/app/helmrelease.yaml
@@ -9,68 +9,70 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       interval: 30m
       sourceRef:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
   values:
-    controller:
-      type: statefulset
-      annotations:
-        reloader.stakater.com/auto: "true"
-
-    image:
-      repository: quay.io/prometheus/alertmanager
-      tag: v0.32.1
-
-    podAnnotations:
-      reloader.stakater.com/auto: "true"
-
+    controllers:
+      alertmanager:
+        type: statefulset
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          annotations:
+            reloader.stakater.com/auto: "true"
+        statefulset:
+          volumeClaimTemplates:
+            - name: storage
+              accessMode: ReadWriteOnce
+              size: 50Mi
+              storageClass: "${STORAGE_CLASS_DEFAULT}"
+              globalMounts:
+                - path: /alertmanager
+        containers:
+          app:
+            image:
+              repository: quay.io/prometheus/alertmanager
+              tag: v0.32.1
+            resources:
+              requests:
+                cpu: 11m
+                memory: 50M
+              limits:
+                memory: 99M
     service:
-      main:
+      app:
+        controller: alertmanager
         ports:
           http:
             port: 9093
-
+    persistence:
+      config:
+        type: configMap
+        name: alertmanager-configmap
+        globalMounts:
+          - path: /etc/alertmanager
+            readOnly: true
+      secrets:
+        type: secret
+        name: alertmanager-secrets
+        globalMounts:
+          - path: /etc/secrets
+            readOnly: true
     ingress:
-      main:
-        enabled: true
-        ingressClassName: nginx-internal
+      app:
+        className: nginx-internal
         hosts:
           - host: &host alertmanager.${INTERNAL_DOMAIN}
             paths:
               - path: /
                 pathType: Prefix
+                service:
+                  identifier: app
+                  port: http
         tls:
           - hosts:
               - *host
-
-    persistence:
-      config:
-        enabled: true
-        type: configMap
-        name: alertmanager-configmap
-        mountPath: /etc/alertmanager
-        readOnly: true
-      secrets:
-        enabled: true
-        type: secret
-        name: alertmanager-secrets
-        mountPath: /etc/secrets
-        readOnly: true
-
-    resources:
-      requests:
-        cpu: 11m
-        memory: 50M
-      limits:
-        memory: 99M
-
-    volumeClaimTemplates:
-      - name: storage
-        mountPath: /alertmanager
-        accessMode: ReadWriteOnce
-        size: 50Mi
-        storageClass: "${STORAGE_CLASS_DEFAULT}"

--- a/kubernetes/apps/monitoring/unms-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/unms-exporter/app/helmrelease.yaml
@@ -9,44 +9,45 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       interval: 30m
       sourceRef:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-
   values:
-    image:
-      repository: quay.io/ffddorf/unms-exporter
-      tag: sha-4c13c27@sha256:7200af98df05fcea2e85b29c440b24e9da32905665cec192c5f87b1714d37f4e
-
-    env:
-      UNMS_EXPORTER_TOKEN:
-        valueFrom:
-          secretKeyRef:
-            name: unms-exporter-secrets
-            key: UNMS_EXPORTER_TOKEN
-
+    controllers:
+      unms-exporter:
+        containers:
+          app:
+            image:
+              repository: quay.io/ffddorf/unms-exporter
+              tag: sha-4c13c27@sha256:7200af98df05fcea2e85b29c440b24e9da32905665cec192c5f87b1714d37f4e
+            env:
+              UNMS_EXPORTER_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: unms-exporter-secrets
+                    key: UNMS_EXPORTER_TOKEN
+            resources:
+              requests:
+                cpu: 10m
+                memory: 100Mi
+              limits:
+                memory: 500Mi
     service:
-      main:
+      app:
+        controller: unms-exporter
         ports:
           http:
             port: 9806
-
     serviceMonitor:
-      main:
+      app:
         enabled: ${SERVICE_MONITOR_ENABLED}
+        serviceName: unms-exporter
         endpoints:
           - port: http
             scheme: http
             path: /metrics
             interval: 2m
             scrapeTimeout: 5s
-
-    resources:
-      requests:
-        cpu: 10m
-        memory: 100Mi
-      limits:
-        memory: 500Mi

--- a/kubernetes/apps/monitoring/unpoller/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/unpoller/app/helmrelease.yaml
@@ -9,49 +9,50 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       interval: 30m
       sourceRef:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-
   values:
-    image:
-      repository: ghcr.io/unpoller/unpoller
-      tag: v2.9.4@sha256:20c161781ac544a7548c8dd533f13498201746efdf0853d4625a1dbfd5652a19
-
-    env:
-      UP_UNIFI_DEFAULT_ROLE: tnwks-ops
-      UP_UNIFI_DEFAULT_URL: https://unifi:8443
-      UP_UNIFI_DEFAULT_VERIFY_SSL: false
-      UP_UNIFI_DEFAULT_USER: unifipoller
-      UP_UNIFI_DEFAULT_PASS:
-        valueFrom:
-          secretKeyRef:
-            name: unpoller-secrets
-            key: unifipoller_password
-      UP_INFLUXDB_DISABLE: true
-
+    controllers:
+      unpoller:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/unpoller/unpoller
+              tag: v2.9.4@sha256:20c161781ac544a7548c8dd533f13498201746efdf0853d4625a1dbfd5652a19
+            env:
+              UP_UNIFI_DEFAULT_ROLE: tnwks-ops
+              UP_UNIFI_DEFAULT_URL: https://unifi:8443
+              UP_UNIFI_DEFAULT_VERIFY_SSL: false
+              UP_UNIFI_DEFAULT_USER: unifipoller
+              UP_UNIFI_DEFAULT_PASS:
+                valueFrom:
+                  secretKeyRef:
+                    name: unpoller-secrets
+                    key: unifipoller_password
+              UP_INFLUXDB_DISABLE: true
+            resources:
+              requests:
+                cpu: 10m
+                memory: 100Mi
+              limits:
+                memory: 500Mi
     service:
-      main:
+      app:
+        controller: unpoller
         ports:
           http:
             port: 9130
-
     serviceMonitor:
-      main:
+      app:
         enabled: ${SERVICE_MONITOR_ENABLED}
+        serviceName: unpoller
         endpoints:
           - port: http
             scheme: http
             path: /metrics
             interval: 2m # Unifi API only polls at 2m intervals
             scrapeTimeout: 5s
-
-    resources:
-      requests:
-        cpu: 10m
-        memory: 100Mi
-      limits:
-        memory: 500Mi

--- a/kubernetes/apps/monitoring/vector/agent/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/vector/agent/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       interval: 30m
       sourceRef:
         kind: HelmRepository
@@ -16,99 +16,91 @@ spec:
         namespace: flux-system
   interval: 30m
   values:
-    controller:
-      type: daemonset
-      strategy: RollingUpdate
-      annotations:
-        reloader.stakater.com/auto: "true"
-
-    image:
-      repository: ghcr.io/onedr0p/vector
-      tag: 0.34.1-debian@sha256:329ceb648d40a26fca9f72c851e9abbacef74cc50b7956d9cf7eb1929d57f35c
-
-    args: ["--config", "/etc/vector/vector.yaml"]
-
-    env:
-      PROCFS_ROOT: /host/proc
-      SYSFS_ROOT: /host/sys
-      VECTOR_SELF_NODE_NAME:
-        valueFrom:
-          fieldRef:
-            apiVersion: v1
-            fieldPath: spec.nodeName
-      VECTOR_SELF_POD_NAME:
-        valueFrom:
-          fieldRef:
-            apiVersion: v1
-            fieldPath: metadata.name
-      VECTOR_SELF_POD_NAMESPACE:
-        valueFrom:
-          fieldRef:
-            apiVersion: v1
-            fieldPath: metadata.namespace
-
-    persistence:
-      config:
-        enabled: true
-        type: configMap
-        name: vector-agent-configmap
-        subPath: vector.yaml
-        mountPath: /etc/vector/vector.yaml
-        readOnly: true
-      data:
-        enabled: true
-        type: emptyDir
-        mountPath: /vector-data-dir
-      var-log:
-        enabled: true
-        type: hostPath
-        hostPath: /var/log
-        hostPathType: Directory
-        mountPath: /var/log
-        readOnly: true
-      var-lib:
-        enabled: true
-        type: hostPath
-        hostPath: /var/lib
-        hostPathType: Directory
-        mountPath: /var/lib
-        readOnly: true
-      procfs:
-        enabled: true
-        type: hostPath
-        hostPath: /proc
-        hostPathType: Directory
-        mountPath: /host/proc
-        readOnly: true
-      sysfs:
-        enabled: true
-        type: hostPath
-        hostPath: /sys
-        hostPathType: Directory
-        mountPath: /host/sys
-        readOnly: true
-
-    podMonitor:
-      enabled: true
-
-    resources:
-      requests:
-        cpu: 23m
-        memory: 249M
-      # limits:
-      #   memory: 918M
-
-    securityContext:
-      privileged: true
-
-    service:
-      main:
-        enabled: false
-
+    defaultPodOptions:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+    controllers:
+      vector-agent:
+        type: daemonset
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/onedr0p/vector
+              tag: 0.34.1-debian@sha256:329ceb648d40a26fca9f72c851e9abbacef74cc50b7956d9cf7eb1929d57f35c
+            args: ["--config", "/etc/vector/vector.yaml"]
+            env:
+              PROCFS_ROOT: /host/proc
+              SYSFS_ROOT: /host/sys
+              VECTOR_SELF_NODE_NAME:
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: spec.nodeName
+              VECTOR_SELF_POD_NAME:
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
+              VECTOR_SELF_POD_NAMESPACE:
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 23m
+                memory: 249M
     serviceAccount:
       create: true
       name: vector-agent
-
-    tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+    serviceMonitor:
+      app:
+        serviceName: vector-agent
+        endpoints:
+          - port: metrics
+    persistence:
+      config:
+        type: configMap
+        name: vector-agent-configmap
+        globalMounts:
+          - path: /etc/vector/vector.yaml
+            subPath: vector.yaml
+            readOnly: true
+      data:
+        type: emptyDir
+        globalMounts:
+          - path: /vector-data-dir
+      var-log:
+        type: hostPath
+        hostPath: /var/log
+        hostPathType: Directory
+        globalMounts:
+          - path: /var/log
+            readOnly: true
+      var-lib:
+        type: hostPath
+        hostPath: /var/lib
+        hostPathType: Directory
+        globalMounts:
+          - path: /var/lib
+            readOnly: true
+      procfs:
+        type: hostPath
+        hostPath: /proc
+        hostPathType: Directory
+        globalMounts:
+          - path: /host/proc
+            readOnly: true
+      sysfs:
+        type: hostPath
+        hostPath: /sys
+        hostPathType: Directory
+        globalMounts:
+          - path: /host/sys
+            readOnly: true

--- a/kubernetes/apps/monitoring/vector/aggregator/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/vector/aggregator/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       interval: 30m
       sourceRef:
         kind: HelmRepository
@@ -19,89 +19,55 @@ spec:
         namespace: flux-system
   interval: 30m
   values:
-    controller:
-      replicas: 1
-      strategy: Recreate
-      annotations:
-        reloader.stakater.com/auto: "true"
-
-    # initContainers:
-    #   01-init-geoip:
-    #     image: ghcr.io/maxmind/geoipupdate:v6.0.0@sha256:e0d5c1dee7379d360e0f355557542d9672c616215dfdd5aaf917382de84cb84c
-    #     imagePullPolicy: IfNotPresent
-    #     env:
-    #       - name: GEOIPUPDATE_EDITION_IDS
-    #         value: GeoLite2-City
-    #       - name: GEOIPUPDATE_FREQUENCY
-    #         value: "0"
-    #       - name: GEOIPUPDATE_VERBOSE
-    #         value: "true"
-    #     envFrom:
-    #       - secretRef:
-    #           name: vector-aggregator-secret
-    #     volumeMounts:
-    #       - name: geoip
-    #         mountPath: /usr/share/GeoIP
-
-    image:
-      repository: ghcr.io/onedr0p/vector
-      tag: 0.34.1-debian@sha256:329ceb648d40a26fca9f72c851e9abbacef74cc50b7956d9cf7eb1929d57f35c
-
-    args:
-      - "--config"
-      - "/etc/vector/vector.yaml"
-
+    defaultPodOptions:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: vector-aggregator
+    controllers:
+      vector-aggregator:
+        replicas: 1
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/onedr0p/vector
+              tag: 0.34.1-debian@sha256:329ceb648d40a26fca9f72c851e9abbacef74cc50b7956d9cf7eb1929d57f35c
+            args:
+              - "--config"
+              - "/etc/vector/vector.yaml"
     service:
-      main:
+      app:
+        controller: vector-aggregator
         type: LoadBalancer
         annotations:
           external-dns.alpha.kubernetes.io/hostname: "vector.${INTERNAL_DOMAIN}"
-          #io.cilium/lb-ipam-ips: "10.45.0.2"
         externalTrafficPolicy: Cluster
         ports:
           http:
             port: 8686
           kubernetes-logs:
-            enabled: true
             port: 6000
           vyos-syslog:
-            enabled: true
             port: 6001
           journald-logs:
-            enabled: true
             port: 6002
           pve-syslog:
-            enabled: true
             port: 6003
-
     persistence:
       config:
-        enabled: true
         type: configMap
         name: vector-aggregator-configmap
-        subPath: vector.yaml
-        mountPath: /etc/vector/vector.yaml
-        readOnly: true
+        globalMounts:
+          - path: /etc/vector/vector.yaml
+            subPath: vector.yaml
+            readOnly: true
       data:
-        enabled: true
         type: emptyDir
-        mountPath: /vector-data-dir
-      # geoip:
-      #   enabled: true
-      #   type: emptyDir
-      #   mountPath: /usr/share/GeoIP
-
-    # resources:
-    #   requests:
-    #     cpu: 35m
-    #     memory: 381M
-    #   limits:
-    #     memory: 726M
-
-    topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: DoNotSchedule
-        labelSelector:
-          matchLabels:
-            app.kubernetes.io/name: vector-aggregator
+        globalMounts:
+          - path: /vector-data-dir

--- a/kubernetes/apps/networking/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/cloudflared/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       sourceRef:
         kind: HelmRepository
         name: bjw-s
@@ -26,77 +26,86 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    controller:
-      replicas: 1
-      strategy: RollingUpdate
-      annotations:
-        reloader.stakater.com/auto: "true"
-    image:
-      repository: docker.io/cloudflare/cloudflared
-      tag: 2026.5.1
-    env:
-      NO_AUTOUPDATE: "true"
-      TUNNEL_CRED_FILE: /etc/cloudflared/creds/credentials.json
-      TUNNEL_METRICS: 0.0.0.0:8080
-      TUNNEL_TRANSPORT_PROTOCOL: auto
-      TUNNEL_ID:
-        valueFrom:
-          secretKeyRef:
-            name: cloudflared-secret
-            key: TUNNEL_ID
-    args:
-      - tunnel
-      - --config
-      - /etc/cloudflared/config/config.yaml
-      - run
-      - "$(TUNNEL_ID)"
+    controllers:
+      cloudflared:
+        replicas: 1
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/cloudflare/cloudflared
+              tag: 2026.5.1
+            env:
+              NO_AUTOUPDATE: "true"
+              TUNNEL_CRED_FILE: /etc/cloudflared/creds/credentials.json
+              TUNNEL_METRICS: 0.0.0.0:8080
+              TUNNEL_TRANSPORT_PROTOCOL: auto
+              TUNNEL_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: cloudflared-secret
+                    key: TUNNEL_ID
+            args:
+              - tunnel
+              - --config
+              - /etc/cloudflared/config/config.yaml
+              - run
+              - "$(TUNNEL_ID)"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ready
+                    port: 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 5m
+                memory: 10Mi
+              limits:
+                memory: 256Mi
     service:
-      main:
+      app:
+        controller: cloudflared
         ports:
           http:
             port: 8080
     serviceMonitor:
-      main:
+      app:
         enabled: ${SERVICE_MONITOR_ENABLED}
+        serviceName: cloudflared
         endpoints:
           - port: http
             scheme: http
             path: /metrics
             interval: 1m
             scrapeTimeout: 30s
-    probes:
-      liveness: &probes
-        enabled: true
-        custom: true
-        spec:
-          httpGet:
-            path: /ready
-            port: http
-          initialDelaySeconds: 0
-          periodSeconds: 10
-          timeoutSeconds: 1
-          failureThreshold: 3
-      readiness: *probes
-      startup:
-        enabled: false
     persistence:
       config:
-        enabled: true
         type: configMap
         name: cloudflared-configmap
-        subPath: config.yaml
-        mountPath: /etc/cloudflared/config/config.yaml
-        readOnly: true
+        advancedMounts:
+          cloudflared:
+            app:
+              - subPath: config.yaml
+                path: /etc/cloudflared/config/config.yaml
+                readOnly: true
       creds:
-        enabled: true
         type: secret
         name: cloudflared-secret
-        subPath: credentials.json
-        mountPath: /etc/cloudflared/creds/credentials.json
-        readOnly: true
-    resources:
-      requests:
-        cpu: 5m
-        memory: 10Mi
-      limits:
-        memory: 256Mi
+        advancedMounts:
+          cloudflared:
+            app:
+              - subPath: credentials.json
+                path: /etc/cloudflared/creds/credentials.json
+                readOnly: true

--- a/kubernetes/apps/production/changedetection/app/helmrelease.yaml
+++ b/kubernetes/apps/production/changedetection/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       sourceRef:
         kind: HelmRepository
         name: bjw-s
@@ -26,46 +26,54 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    controller:
-      type: statefulset
-    image:
-      repository: ghcr.io/dgtlmoon/changedetection.io
-      tag: "0.55.5"
-    env:
-      TZ: ${TIMEZONE}
-      PORT: &port 5000
-      PUID: 568
-      PGID: 568
-      BASE_URL: https://changedetection.${SECRET_DOMAIN}
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      changedetection:
+        type: statefulset
+        statefulset:
+          volumeClaimTemplates:
+            - name: config
+              accessMode: ReadWriteOnce
+              size: 1Gi
+              storageClass: "${STORAGE_CLASS_DEFAULT}"
+              globalMounts:
+                - path: /datastore
+        containers:
+          app:
+            image:
+              repository: ghcr.io/dgtlmoon/changedetection.io
+              tag: "0.55.5"
+            env:
+              TZ: ${TIMEZONE}
+              PORT: &port 5000
+              PUID: 568
+              PGID: 568
+              BASE_URL: https://changedetection.${SECRET_DOMAIN}
+            resources:
+              requests:
+                cpu: 10m
+                memory: 100Mi
+              limits:
+                memory: 500Mi
     service:
-      main:
+      app:
+        controller: changedetection
         ports:
           http:
             port: *port
-
     ingress:
       internal:
-        enabled: true
-        ingressClassName: "nginx-internal"
+        className: nginx-internal
         hosts:
           - host: &internalHost "changedetection.${INTERNAL_DOMAIN}"
             paths:
               - path: /
-
-    podSecurityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
-      fsGroupChangePolicy: OnRootMismatch
-    volumeClaimTemplates:
-      - name: config
-        mountPath: /datastore
-        accessMode: ReadWriteOnce
-        size: 1Gi
-        storageClass: "${STORAGE_CLASS_DEFAULT}"
-    resources:
-      requests:
-        cpu: 10m
-        memory: 100Mi
-      limits:
-        memory: 500Mi
+                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http

--- a/kubernetes/apps/production/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/production/frigate/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 2.4.0
+      version: 3.7.3
       sourceRef:
         kind: HelmRepository
         name: bjw-s
@@ -24,12 +24,15 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      nodeSelector:
+        google.feature.node.kubernetes.io/coral: "true"
     controllers:
-      main:
+      frigate:
         annotations:
           reloader.stakater.com/auto: "true"
         containers:
-          main:
+          app:
             image:
               repository: ghcr.io/blakeblackshear/frigate
               tag: 0.17.0-rc1@sha256:c758ec715d23d44d0cadde9d1ff884ca80f7364992de7e2401cf29ebb3f3d5f1
@@ -60,11 +63,9 @@ spec:
                 cpu: 5000m
               limits:
                 memory: 8Gi
-        pod:
-          nodeSelector:
-            google.feature.node.kubernetes.io/coral: "true"
     service:
-      main:
+      app:
+        controller: frigate
         ports:
           http:
             port: *port
@@ -73,29 +74,28 @@ spec:
           webrtc-tcp:
             port: 8555
             protocol: TCP
-      mainudp:
-        controller: main
+      appudp:
+        controller: frigate
         ports:
           webrtc-udp:
             port: 8555
             protocol: UDP
     ingress:
-      main:
-        enabled: true
+      app:
         className: nginx-internal
         hosts:
           - host: &host "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
             paths:
               - path: /
+                pathType: Prefix
                 service:
-                  name: main
+                  identifier: app
                   port: http
     persistence:
       config:
         accessMode: ReadWriteOnce
         size: 1Gi
         storageClass: "${STORAGE_CLASS_DEFAULT}"
-        enabled: true
         globalMounts:
           - path: /data
       config-file:
@@ -106,21 +106,18 @@ spec:
             subPath: config.yml
             readOnly: true
       cache:
-        enabled: true
         type: emptyDir
         medium: Memory
         sizeLimit: 4Gi
         globalMounts:
           - path: /dev/shm
       usb:
-        enabled: true
         type: hostPath
         hostPath: /dev/bus/usb
         hostPathType: Directory
         globalMounts:
           - path: /dev/bus/usb
       media:
-        enabled: true
         accessMode: ReadWriteOnce
         size: 1Gi
         storageClass: "${STORAGE_CLASS_DEFAULT}"

--- a/kubernetes/apps/production/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/production/jellyfin/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       sourceRef:
         kind: HelmRepository
         name: bjw-s
@@ -26,33 +26,58 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
-
   values:
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: node-role.kubernetes.io/control-plane
-                  operator: DoesNotExist
-
-    controller:
-      type: statefulset
-    image:
-      repository: jellyfin/jellyfin
-      tag: 10.11.10
-    env:
-      TZ: "America/Los_Angeles"
-
+    defaultPodOptions:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: "OnRootMismatch"
+        supplementalGroups: [44, 109, 10000]
+    controllers:
+      jellyfin:
+        type: statefulset
+        containers:
+          app:
+            image:
+              repository: jellyfin/jellyfin
+              tag: 10.11.10
+            env:
+              TZ: "America/Los_Angeles"
+            resources:
+              requests:
+                memory: 512Mi
+              limits:
+                memory: 6Gi
     service:
-      main:
+      app:
+        controller: jellyfin
         ports:
           http:
             port: 8096
-
-    ingress:
-      main:
+    persistence:
+      config:
         enabled: true
+        storageClass: ${STORAGE_CLASS_DEFAULT}
+        accessMode: ReadWriteOnce
+        size: 150Gi
+        retain: true
+        globalMounts:
+          - path: /config
+      cephfs:
+        existingClaim: cephfs-hdd-subvolume
+        globalMounts:
+          - path: /cephfs
+    ingress:
+      app:
+        className: nginx
         annotations:
           external-dns.alpha.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
           hajimari.io/icon: simple-icons:jellyfin
@@ -61,41 +86,19 @@ spec:
             paths:
               - path: /
                 pathType: Prefix
-        ingressClassName: nginx
+                service:
+                  identifier: app
+                  port: http
         tls:
           - hosts:
               - *host
-
       internal:
-        enabled: true
-        ingressClassName: "nginx-internal"
+        className: nginx-internal
         hosts:
           - host: &internalHost "jellyfin.${INTERNAL_DOMAIN}"
             paths:
               - path: /
-
-    resources:
-      requests:
-        memory: 512m
-      limits:
-        memory: 6Gi
-
-    podSecurityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
-      fsGroupChangePolicy: "OnRootMismatch"
-      supplementalGroups: [44, 109, 10000]
-
-    persistence:
-      config:
-        enabled: true
-        storageClass: ${STORAGE_CLASS_DEFAULT}
-        accessMode: ReadWriteOnce
-        size: 150Gi
-        retain: true
-
-      cephfs:
-        enabled: true
-        existingClaim: cephfs-hdd-subvolume
-        mountPath: /cephfs
+                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http

--- a/kubernetes/apps/production/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/production/mealie/app/helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       sourceRef:
         kind: HelmRepository
         name: bjw-s
@@ -25,43 +25,60 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    env:
-      - name: TZ
-        value: "${TIMEZONE}"
-      - name: DB_ENGINE
-        value: "postgres"
-      # cnpg generates the `postgres-app` Secret in the databases
-      # namespace with all the connection bits; cross-namespace fetch
-      # via the postgres-app Secret mirrored into this namespace by
-      # external-secrets / reflector. For now we point at the cnpg
-      # services + DB credentials directly.
-      - name: POSTGRES_USER
-        valueFrom:
-          secretKeyRef:
-            name: postgres-app
-            key: username
-      - name: POSTGRES_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: postgres-app
-            key: password
-      - name: POSTGRES_SERVER
-        # cnpg's read-write Service. Cross-namespace via FQDN.
-        value: "postgres-rw.databases.svc.cluster.local"
-      - name: POSTGRES_PORT
-        value: "5432"
-      # cnpg's `postgres-app` Secret only carries username/password/pgpass.
-      # The DB name comes from cluster.yaml's `bootstrap.initdb.database`
-      # field (`app`).
-      - name: POSTGRES_DB
-        value: "app"
-
-    image:
-      repository: docker.io/hkotel/mealie
-      tag: v0.5.6
-    ingress:
-      main:
+    controllers:
+      mealie:
+        containers:
+          app:
+            image:
+              repository: docker.io/hkotel/mealie
+              tag: v0.5.6
+            env:
+              - name: TZ
+                value: "${TIMEZONE}"
+              - name: DB_ENGINE
+                value: "postgres"
+              # cnpg generates the `postgres-app` Secret in the databases
+              # namespace with all the connection bits; cross-namespace fetch
+              # via the postgres-app Secret mirrored into this namespace by
+              # external-secrets / reflector. For now we point at the cnpg
+              # services + DB credentials directly.
+              - name: POSTGRES_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: postgres-app
+                    key: username
+              - name: POSTGRES_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: postgres-app
+                    key: password
+              - name: POSTGRES_SERVER
+                # cnpg's read-write Service. Cross-namespace via FQDN.
+                value: "postgres-rw.databases.svc.cluster.local"
+              - name: POSTGRES_PORT
+                value: "5432"
+              # cnpg's `postgres-app` Secret only carries username/password/pgpass.
+              # The DB name comes from cluster.yaml's `bootstrap.initdb.database`
+              # field (`app`).
+              - name: POSTGRES_DB
+                value: "app"
+    service:
+      app:
+        controller: mealie
+        ports:
+          http:
+            port: 80
+    persistence:
+      config:
         enabled: true
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        storageClass: ${STORAGE_CLASS_DEFAULT}
+        globalMounts:
+          - path: /app/data
+    ingress:
+      app:
+        className: nginx
         annotations:
           external-dns.alpha.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
           hajimari.io/appName: Recipes
@@ -72,21 +89,9 @@ spec:
             paths:
               - path: /
                 pathType: Prefix
-        ingressClassName: nginx
+                service:
+                  identifier: app
+                  port: http
         tls:
           - hosts:
               - *host
-
-    persistence:
-      config:
-        enabled: true
-        mountPath: /app/data
-        storageClass: ${STORAGE_CLASS_DEFAULT}
-        size: 5Gi
-
-    service:
-      main:
-        ports:
-          http:
-            port: 80
-

--- a/kubernetes/apps/production/uisp/app/helmrelease.yaml
+++ b/kubernetes/apps/production/uisp/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       sourceRef:
         kind: HelmRepository
         name: bjw-s
@@ -26,34 +26,54 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    controller:
-      type: statefulset
-      annotations:
-        reloader.stakater.com/auto: "true"
-      startupProbe:
-        failureThreshhold: 50
-        periodSeconds: 10
-    image:
-      repository: nico640/docker-unms
-      tag: 3.0.159
-    env:
-      TZ: ${TIMEZONE}
-      PUID: 911
-      PGID: 911
-      PUBLIC_HTTPS_PORT: 443
-      PUBLIC_WS_PORT: 443
-
+    controllers:
+      uisp:
+        type: statefulset
+        annotations:
+          reloader.stakater.com/auto: "true"
+        statefulset:
+          volumeClaimTemplates:
+            - name: config
+              accessMode: ReadWriteOnce
+              size: 5Gi
+              storageClass: "${STORAGE_CLASS_DEFAULT}"
+              globalMounts:
+                - path: /config
+        containers:
+          app:
+            image:
+              repository: nico640/docker-unms
+              tag: 3.0.159
+            env:
+              TZ: ${TIMEZONE}
+              PUID: 911
+              PGID: 911
+              PUBLIC_HTTPS_PORT: 443
+              PUBLIC_WS_PORT: 443
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  failureThreshold: 50
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 8000m
+                memory: 4Gi
+              limits:
+                cpu: 8000m
+                memory: 4Gi
     service:
-      main:
+      app:
+        controller: uisp
         ports:
           http:
             port: 443
             protocol: HTTPS
-
     ingress:
-      main:
-        enabled: true
-        ingressClassName: nginx
+      app:
+        className: nginx
         annotations:
           external-dns.alpha.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
           nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
@@ -62,22 +82,9 @@ spec:
             paths:
               - path: /
                 pathType: Prefix
-
+                service:
+                  identifier: app
+                  port: http
         tls:
           - hosts:
               - *host
-
-    volumeClaimTemplates:
-      - name: config
-        mountPath: /config
-        accessMode: ReadWriteOnce
-        size: 5Gi
-        storageClass: "${STORAGE_CLASS_DEFAULT}"
-
-    resources:
-      requests:
-        cpu: 8000m
-        memory: 4Gi
-      limits:
-        cpu: 8000m
-        memory: 4Gi

--- a/kubernetes/apps/production/vaultwarden/app/helmrelease.yaml
+++ b/kubernetes/apps/production/vaultwarden/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       sourceRef:
         kind: HelmRepository
         name: bjw-s
@@ -27,44 +27,52 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    image:
-      repository: vaultwarden/server
-      tag: 1.36.0
-    env:
-      DATA_FOLDER: "config"
-      DOMAIN: "https://vaultwarden.${SECRET_DOMAIN}"
-      TZ: "${TIMEZONE}"
-      SIGNUPS_ALLOWED: "false"
-      WEBSOCKET_ENABLED: "true"
-      WEBSOCKET_ADDRESS: 0.0.0.0
-      WEBSOCKET_PORT: 3012
-      SMTP_HOST: "email-smtp.us-west-2.amazonaws.com"
-      SMTP_FROM: vaultwarden@${SECRET_DOMAIN}
-      SMTP_FROM_NAME: vaultwarden
-      SMTP_PORT: 587
-      SMTP_SECURITY: "off"
-      DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_SERVER}/bitwarden"
-
+    controllers:
+      vaultwarden:
+        containers:
+          app:
+            image:
+              repository: vaultwarden/server
+              tag: 1.36.0
+            env:
+              DATA_FOLDER: "config"
+              DOMAIN: "https://vaultwarden.${SECRET_DOMAIN}"
+              TZ: "${TIMEZONE}"
+              SIGNUPS_ALLOWED: "false"
+              WEBSOCKET_ENABLED: "true"
+              WEBSOCKET_ADDRESS: 0.0.0.0
+              WEBSOCKET_PORT: 3012
+              SMTP_HOST: "email-smtp.us-west-2.amazonaws.com"
+              SMTP_FROM: vaultwarden@${SECRET_DOMAIN}
+              SMTP_FROM_NAME: vaultwarden
+              SMTP_PORT: 587
+              SMTP_SECURITY: "off"
+              DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_SERVER}/bitwarden"
+            resources:
+              requests:
+                cpu: 100m
+                memory: 100Mi
+              limits:
+                memory: 2Gi
     service:
-      main:
+      app:
+        controller: vaultwarden
         ports:
           http:
             port: &port 80
           websocket:
-            enabled: true
             port: &websocket-port 3012
-
     persistence:
       config:
         enabled: true
-        retain: true
         accessMode: ReadWriteOnce
         size: 1Gi
-
+        retain: true
+        globalMounts:
+          - path: /config
     ingress:
-      main:
-        enabled: true
-        ingressClassName: "nginx"
+      app:
+        className: nginx
         annotations:
           external-dns.alpha.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
           hajimari.io/icon: mdi:lock
@@ -74,21 +82,18 @@ spec:
               - path: /
                 pathType: Prefix
                 service:
-                  port: *port
+                  identifier: app
+                  port: http
               - path: /notifications/hub/negotiate
                 pathType: Prefix
                 service:
-                  port: *port
+                  identifier: app
+                  port: http
               - path: /notifications/hub
                 pathType: Prefix
                 service:
-                  port: *websocket-port
+                  identifier: app
+                  port: websocket
         tls:
           - hosts:
               - *host
-    resources:
-      requests:
-        cpu: 100m
-        memory: 100Mi
-      limits:
-        memory: 2Gi

--- a/kubernetes/apps/production/wizarr/app/helmrelease.yaml
+++ b/kubernetes/apps/production/wizarr/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 3.7.3
       sourceRef:
         kind: HelmRepository
         name: bjw-s
@@ -26,28 +26,44 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    controller:
-      type: statefulset
-      annotations:
-        reloader.stakater.com/auto: "true"
-    image:
-      repository: ghcr.io/wizarrrr/wizarr
-      # 3.5.2 was GC'd from ghcr.io entirely (tag and digest gone).
-      # Wizarr's 4.x line has been out for a while; bump to current.
-      tag: 4.2.0
-    env:
-      TZ: ${TIMEZONE}
-      APP_URL: https://invite.${SECRET_DOMAIN}
-      DISABLE_BUILTIN_AUTH: "false"
+    controllers:
+      wizarr:
+        type: statefulset
+        annotations:
+          reloader.stakater.com/auto: "true"
+        statefulset:
+          volumeClaimTemplates:
+            - name: config
+              accessMode: ReadWriteOnce
+              size: 1Gi
+              globalMounts:
+                - path: /data/database
+        containers:
+          app:
+            image:
+              repository: ghcr.io/wizarrrr/wizarr
+              # 3.5.2 was GC'd from ghcr.io entirely (tag and digest gone).
+              # Wizarr's 4.x line has been out for a while; bump to current.
+              tag: 4.2.0
+            env:
+              TZ: ${TIMEZONE}
+              APP_URL: https://invite.${SECRET_DOMAIN}
+              DISABLE_BUILTIN_AUTH: "false"
+            resources:
+              requests:
+                cpu: 15m
+                memory: 180M
+              limits:
+                memory: 300M
     service:
-      main:
+      app:
+        controller: wizarr
         ports:
           http:
             port: 5690
     ingress:
-      main:
-        enabled: true
-        ingressClassName: nginx
+      app:
+        className: nginx
         annotations:
           external-dns.alpha.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
         hosts:
@@ -55,17 +71,9 @@ spec:
             paths:
               - path: /
                 pathType: Prefix
+                service:
+                  identifier: app
+                  port: http
         tls:
           - hosts:
               - *host
-    volumeClaimTemplates:
-      - name: config
-        mountPath: /data/database
-        accessMode: ReadWriteOnce
-        size: 1Gi
-    resources:
-      requests:
-        cpu: 15m
-        memory: 180M
-      limits:
-        memory: 300M

--- a/kubernetes/apps/selfhosted/obsidian-couchdb/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/obsidian-couchdb/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 2.4.0
+      version: 3.7.3
       interval: 30m
       sourceRef:
         kind: HelmRepository
@@ -18,13 +18,17 @@ spec:
         namespace: flux-system
 
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: "OnRootMismatch"
     controllers:
-      main:
+      obsidian-couchdb:
         type: statefulset
-
         annotations:
           reloader.stakater.com/auto: "true"
-
         statefulset:
           volumeClaimTemplates:
             - name: data
@@ -33,14 +37,6 @@ spec:
               storageClass: "${STORAGE_CLASS_DEFAULT}"
               globalMounts:
                 - path: /opt/couchdb/data
-
-        pod:
-          securityContext:
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: "OnRootMismatch"
-
         initContainers:
           init-config:
             image:
@@ -51,9 +47,8 @@ spec:
               - "/bin/sh"
               - "-c"
               - "cp /tmp/config/*.ini /opt/couchdb/etc/default.d/; ls -lrt /opt/couchdb/etc/default.d;"
-
         containers:
-          main:
+          app:
             image:
               repository: public.ecr.aws/docker/library/couchdb
               tag: 3.5.1
@@ -74,36 +69,32 @@ spec:
                 memory: 146M
               limits:
                 memory: 1Gi
-
     service:
-      main:
+      app:
+        controller: obsidian-couchdb
         ports:
           http:
             port: 5984
-
     ingress:
-      main:
-        enabled: true
+      app:
         className: nginx-internal
         hosts:
           - host: &host "obsidian-couchdb.${INTERNAL_DOMAIN}"
             paths:
               - path: /
+                pathType: Prefix
                 service:
-                  name: main
+                  identifier: app
                   port: http
-
     persistence:
       config:
-        enabled: true
         type: configMap
         name: obsidian-couchdb-configmap
         advancedMounts:
-          main:
+          obsidian-couchdb:
             init-config:
               - path: /tmp/config
       config-storage:
-        enabled: true
         type: emptyDir
         globalMounts:
           - path: /opt/couchdb/etc/default.d


### PR DESCRIPTION
## Summary

Bulk migration of remaining HelmReleases off bjw-s app-template 1.x / 2.x onto 3.7.3, unblocking the upstream chart-version PRs that were stuck on this schema rewrite.

24 apps migrated: `home-assistant`, `uisp`, `mosquitto`, `frigate`, `obsidian-couchdb`, `zwave-js-ui`, `peloton-to-garmin` (it+mh), `prowlarr`, `qbittorrent`, `radarr`, `recyclarr`, `sonarr`, `alertmanager`, `unms-exporter`, `unpoller`, `vector-agent`, `vector-aggregator`, `cloudflared`, `changedetection`, `jellyfin`, `mealie`, `vaultwarden`, `wizarr`.

Schema mapping:
- `controller.*` → `controllers.<name>.*`
- `image:` → `controllers.<name>.containers.app.image:` (split repo/tag)
- `volumeClaimTemplates:` → `controllers.<name>.statefulset.volumeClaimTemplates` (with `globalMounts:`)
- `service.main` → `service.app` (with `controller:` + per-port `service.identifier`/`port`)
- `ingress.main` → `ingress.app` (`className`, identifier+port on each path)
- `podSecurityContext` / `nodeSelector` / `affinity` / `topologySpreadConstraints` → under `defaultPodOptions`
- `persistence.<x>.mountPath` → `persistence.<x>.globalMounts[].path`

Notable special cases:
- **qbittorrent**: gluetun sidecar (NET_ADMIN, runs as root) + copy-config init container wired via `advancedMounts`. Dropped `secretKeyRef.optional` on WIREGUARD_PRESHARED_KEY/PORT (3.x schema rejects it).
- **vector-agent**: hostPath mounts (procfs, sysfs, /var/log, /var/lib) under `globalMounts:` with `readOnly: true`.
- **mosquitto**: secret-file → init container, configMap → main container via `advancedMounts:`.

## Test plan

- [x] All 24 files pass `helm template` against bjw-s/app-template 3.7.3 (with stub values for `\${SERVICE_MONITOR_ENABLED}`)
- [ ] Flux reconciles each HelmRelease without schema errors after merge
- [ ] qbittorrent webUI reachable via internal ingress (gluetun sidecar still up)
- [ ] vector-agent DaemonSet collects logs to vector-aggregator
- [ ] StatefulSets retain existing PVCs (volumeClaimTemplate names unchanged)