### PR TITLE
fix(recyclarr): drop invalid restartPolicy override on StatefulSet

### DIFF
--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -17,7 +17,6 @@ spec:
         namespace: flux-system
   values:
     defaultPodOptions:
-      restartPolicy: OnFailure
       securityContext:
         runAsUser: 568
         runAsGroup: 568


### PR DESCRIPTION
## Summary

bjw-s app-template 1.x silently ignored top-level `restartPolicy: OnFailure` on a `controller.type: statefulset` config. 3.x passes it through, and the kube-apiserver rejects the StatefulSet because StatefulSets only support `restartPolicy: Always`.

Drop the override. Recyclarr is a sync tool that runs and exits — the original intent was almost certainly a CronJob, but converting controller type changes the workload kind (and orphans the existing PVC/release). Keeping it as a StatefulSet for now; CronJob conversion can come later as its own change.

## Test plan

- [x] \`helm template\` against bjw-s/app-template 3.7.3 still passes
- [ ] After flux reconcile, recyclarr StatefulSet upgrades cleanly (no immutable-spec error)