### PR TITLE
fix(qbittorrent): mount /config emptyDir so fsGroup takes effect

### DIFF
--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -132,6 +132,18 @@ spec:
           http:
             port: *port
     persistence:
+      # qbittorrent writes its top-level profile under /config (e.g.
+      # /config/qBittorrent/qBittorrent.conf, /config/.cache/...). The
+      # nested mounts below cover /config/qBittorrent/{config,cache,data},
+      # but the intermediate /config dir created by kubelet to host them
+      # is owned root:root and unwritable by uid 568. A top-level
+      # emptyDir mount at /config lets fsGroup=568 take effect there.
+      home:
+        type: emptyDir
+        advancedMounts:
+          qbittorrent:
+            app:
+              - path: /config
       config:
         type: emptyDir
         advancedMounts:


### PR DESCRIPTION
## Summary
- bjw-s 3.x migration switched qbittorrent to nested volume mounts at `/config/qBittorrent/{config,cache,data}`. The intermediate `/config` dir kubelet creates is owned `root:root` and uid 568 can't write its top-level profile (`qBittorrent.conf`, `.cache/qBittorrent`, …), causing crashloop.
- Add a top-level `emptyDir` at `/config` so it's one of the pod's own volumes — `fsGroup=568` then takes effect on it. Nested mounts continue to layer on top.

## Test plan
- [ ] HR reconciles, qbittorrent-0 reaches Ready 2/2
- [ ] `kubectl exec qbittorrent-0 -c app -- ls -la /config` shows uid 568 ownership
- [ ] WebUI loads via internal ingress