### PR TITLE
fix(qbittorrent): chown /config in init since fsGroup isn't propagating

### DIFF
--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -38,6 +38,23 @@ spec:
               globalMounts:
                 - path: /config/qBittorrent/data
         initContainers:
+          # fsGroupChangePolicy: OnRootMismatch isn't chowning intermediate
+          # dirs kubelet creates to host nested mounts (/config/qBittorrent
+          # comes through as root:root despite fsGroup=568), so the app
+          # container — running as 568 — can't write its top-level profile.
+          # Explicitly chown /config recursively before the app starts.
+          00-chown-config:
+            image:
+              repository: public.ecr.aws/docker/library/busybox
+              tag: "1.38.0"
+            command:
+              - "/bin/sh"
+              - -c
+            args:
+              - chown -R 568:568 /config
+            securityContext:
+              runAsUser: 0
+              runAsGroup: 0
           copy-config:
             # No env-var substitution is needed in the bundled config files,
             # so a plain busybox `cp` is sufficient. The previous
@@ -142,6 +159,8 @@ spec:
         type: emptyDir
         advancedMounts:
           qbittorrent:
+            00-chown-config:
+              - path: /config
             app:
               - path: /config
       config:


### PR DESCRIPTION
## Summary
- Follow-up to #1226. The top-level `/config` emptyDir didn't get chowned by `fsGroup=568` on this Talos+WSL kubelet, so qbittorrent (uid 568) still crashlooped on writes to `/config/qBittorrent/qBittorrent.conf`.
- Add a busybox init `00-chown-config` running as root that recursively chowns `/config` before the app starts.

## Test plan
- [ ] HR reconciles, qbittorrent-0 reaches Ready 2/2
- [ ] `kubectl exec qbittorrent-0 -c gluetun -- ls -la /config` shows uid 568 ownership
- [ ] WebUI loads via internal ingress