### PR TITLE
fix(psa): bump home-automation + production namespaces to privileged

### DIFF
--- a/kubernetes/apps/home-automation/namespace.yaml
+++ b/kubernetes/apps/home-automation/namespace.yaml
@@ -5,3 +5,7 @@ metadata:
   name: home-automation
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # zwave-js-ui needs hostPath + securityContext.privileged for the
+    # USB Z-Stick passthrough, both forbidden under PSA baseline.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/kubernetes/apps/production/namespace.yaml
+++ b/kubernetes/apps/production/namespace.yaml
@@ -5,3 +5,7 @@ metadata:
   name: production
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # frigate needs hostPath + securityContext.privileged for the Coral
+    # TPU USB passthrough, both forbidden under PSA baseline.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest


### PR DESCRIPTION
## Summary
- Label the home-automation and production namespaces with \`pod-security.kubernetes.io/enforce: privileged\` so frigate (Coral TPU) and zwave-js-ui (Z-Stick) can run with their required \`securityContext.privileged: true\` and hostPath USB mounts
- Cluster-wide PSA default is \`baseline:latest\`, which rejects both — pods fail to create with \`violates PodSecurity \"baseline:latest\": hostPath volumes (volume \"usb\"), privileged (container \"app\" must not set securityContext.privileged=true)\`, leaving the HelmReleases stuck in install/uninstall remediation loops
- Mirrors existing precedent: \`media\` (gluetun NET_ADMIN) and \`networking\` (MetalLB hostNetwork)

This was blocking the PR #1228 nodeSelector overlay from actually scheduling pods on either cluster.

## Test plan
- [x] Verified events show \`FailedCreate ... violates PodSecurity \"baseline:latest\"\` on \`statefulset/zwave-js-ui\`
- [ ] After Flux reconciles: HRs install cleanly, pods schedule on \`homelab-wsl-worker-2\`