### PR TITLE
docs(wsl-lan-exposure): explain why the sync script + scheduled task exist

### DIFF
--- a/docs/wsl-lan-exposure.md
+++ b/docs/wsl-lan-exposure.md
@@ -25,6 +25,28 @@ Why each hop exists:
   MetalLB VIPs live on the docker bridge, not on `127.0.0.1`, so we need a
   user-space bridge.
 
+### Why the Scheduled Task (and not just one netsh command)?
+
+A single `netsh interface portproxy add` *would* be sufficient if the
+`connectaddress` it points at was stable. It isn't: WSL2's default NAT
+networking mode assigns the WSL VM a fresh IP from the Hyper-V vSwitch on
+every WSL restart and after Windows host reboots. A portproxy rule that
+worked yesterday will silently forward into a black hole tomorrow.
+
+`Sync-TnwksLanBridge.ps1` is what re-derives the current WSL IP (via
+`wsl.exe -d Ubuntu -- hostname -I`) and rewrites the portproxy entries.
+The Scheduled Task registered by `Register-TnwksLanBridgeTask.ps1` runs
+that script at user logon and on Hyper-V `vmswitch` NIC-up events so the
+chain self-heals without manual intervention.
+
+> **Alternative we explicitly didn't take:** WSL2's *mirrored* networking
+> mode (Windows 11 22H2+, `[wsl2] networkingMode=mirrored` in
+> `.wslconfig`) collapses Windows and WSL onto a shared loopback, which
+> would make the portproxy a one-shot. We've stayed on default NAT for
+> compatibility with Talos-in-Docker's bridge networking — switching
+> modes is a separate, larger experiment we haven't validated yet. If
+> that ever changes, the Scheduled Task can go away.
+
 ## Current MetalLB allocations (homelab-wsl)
 
 | Service                              | VIP        | Ports            |


### PR DESCRIPTION
## Summary
- Add a "Why the Scheduled Task (and not just one netsh command)?" subsection to `docs/wsl-lan-exposure.md`
- Explain that WSL2 default NAT networking rotates the WSL VM IP on every restart, so the portproxy `connectaddress` has to be re-derived and re-applied — that's the role of `Sync-TnwksLanBridge.ps1` + the Scheduled Task
- Note WSL2 mirrored networking as the alternative we explicitly chose not to use (Talos-in-Docker bridge compatibility), so a future reader knows the tradeoff was considered

## Test plan
- [x] `docs/wsl-lan-exposure.md` renders cleanly in markdown preview