### PR TITLE
feat(ansible): wsl_lan_bridge role + playbook for the WSL-side socat units

### DIFF
--- a/docs/wsl-lan-exposure.md
+++ b/docs/wsl-lan-exposure.md
@@ -63,22 +63,15 @@ from the LAN side.
 ## One-time setup on the WSL distro
 
 ```bash
-sudo apt-get install -y socat
-
-sudo install -m 0755 \
-  infrastructure/wsl-host/tnwks-lan-bridge.sh \
-  /usr/local/bin/tnwks-lan-bridge
-
-sudo install -m 0644 \
-  infrastructure/wsl-host/tnwks-lan-bridge@.service \
-  /etc/systemd/system/tnwks-lan-bridge@.service
-
-sudo systemctl daemon-reload
-sudo systemctl enable --now \
-  tnwks-lan-bridge@http.service \
-  tnwks-lan-bridge@https.service \
-  tnwks-lan-bridge@mqtt.service
+cd infrastructure/
+ansible-playbook -i ./ansible/inventory/wsl.yml ./ansible/playbooks/wsl-lan-bridge.yml
 ```
+
+The `wsl_lan_bridge` role installs `socat`, drops
+`tnwks-lan-bridge` into `/usr/local/bin/`, the templated systemd unit
+into `/etc/systemd/system/`, and enables+starts one instance per
+LAN-exposed port (`http`, `https`, `mqtt`). Idempotent — only restarts
+units when the script or unit file actually changes.
 
 Verify each unit is active:
 

--- a/infrastructure/ansible/playbooks/wsl-lan-bridge.yml
+++ b/infrastructure/ansible/playbooks/wsl-lan-bridge.yml
@@ -1,0 +1,14 @@
+---
+# Install + enable the LAN-bridge socat units on the WSL host.
+# Pairs with the Windows-side Sync-TnwksLanBridge.ps1; together they
+# expose *.tnwks.local services to the LAN.
+#
+#   ansible-playbook -i ./ansible/inventory/wsl.yml ./ansible/playbooks/wsl-lan-bridge.yml
+#
+# Run from infrastructure/ so ansible.cfg's relative paths resolve.
+
+- hosts: localhost
+  become: true
+  gather_facts: false
+  roles:
+    - ../roles/wsl_lan_bridge

--- a/infrastructure/ansible/roles/wsl_lan_bridge/defaults/main.yml
+++ b/infrastructure/ansible/roles/wsl_lan_bridge/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# Which socat instances to install. Each maps to a 'case' arm in
+# tnwks-lan-bridge.sh: http→ingress 80, https→ingress 443, mqtt→1883.
+# 'dns' is intentionally omitted by default — netsh portproxy is TCP-only,
+# so the LAN-side DNS path goes via VyOS, not via this bridge.
+wsl_lan_bridge_instances:
+  - http
+  - https
+  - mqtt

--- a/infrastructure/ansible/roles/wsl_lan_bridge/tasks/main.yml
+++ b/infrastructure/ansible/roles/wsl_lan_bridge/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+# wsl_lan_bridge — install socat, the bridge script, and the templated
+# systemd unit, then enable+start one instance per LAN-exposed port.
+# See docs/wsl-lan-exposure.md for why this chain exists.
+
+- name: Install socat
+  ansible.builtin.apt:
+    name: socat
+    state: present
+
+- name: Install tnwks-lan-bridge script
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../wsl-host/tnwks-lan-bridge.sh"
+    dest: /usr/local/bin/tnwks-lan-bridge
+    owner: root
+    group: root
+    mode: "0755"
+  register: bridge_script
+
+- name: Install tnwks-lan-bridge templated systemd unit
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../wsl-host/tnwks-lan-bridge@.service"
+    dest: /etc/systemd/system/tnwks-lan-bridge@.service
+    owner: root
+    group: root
+    mode: "0644"
+  register: bridge_unit
+
+- name: Reload systemd if the unit file changed
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: bridge_unit.changed
+
+- name: Enable and start tnwks-lan-bridge instances
+  ansible.builtin.systemd:
+    name: "tnwks-lan-bridge@{{ item }}.service"
+    enabled: true
+    state: started
+  loop: "{{ wsl_lan_bridge_instances }}"
+
+- name: Restart tnwks-lan-bridge instances if script or unit changed
+  ansible.builtin.systemd:
+    name: "tnwks-lan-bridge@{{ item }}.service"
+    state: restarted
+  loop: "{{ wsl_lan_bridge_instances }}"
+  when: bridge_script.changed or bridge_unit.changed


### PR DESCRIPTION
## Summary
- New \`wsl_lan_bridge\` ansible role + \`playbooks/wsl-lan-bridge.yml\` that installs socat, drops the existing \`tnwks-lan-bridge\` script + templated systemd unit, and enables+starts one instance per LAN-exposed port (http, https, mqtt). Idempotent — only restarts units when script/unit content changes
- Update \`docs/wsl-lan-exposure.md\` to point the WSL-side step at the playbook instead of the manual \`install\` + \`systemctl enable --now\` block
- Notes:
  - \`apt update_cache\` is intentionally off — a stale third-party PPA (ubuntugis, unrelated) on the WSL host fails cache refresh; socat is in the base archive so no refresh is needed
  - Role is referenced by relative path (\`../roles/wsl_lan_bridge\`) to match the existing pattern used by \`kasm-install.yml\` etc.

## Test plan
- [x] \`ansible-playbook -i ./ansible/inventory/wsl.yml ./ansible/playbooks/wsl-lan-bridge.yml\` from \`infrastructure/\` runs clean (5 changed, 0 failed)
- [x] \`systemctl is-active 'tnwks-lan-bridge@{http,https,mqtt}.service'\` → all \`active\`
- [x] \`ss -tlnp\` shows \`0.0.0.0:{80,443,1883}\` LISTEN
- [x] \`curl -k -H "Host: jellyfin.tnwks.local" https://10.10.91.142/\` from the LAN side returns 302 (full chain works end-to-end)