### PR TITLE
fix(grafana): make ingress internal-only via nginx-internal + INTERNAL_DOMAIN

### DIFF
--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -43,7 +43,7 @@ spec:
       existingSecret: grafana-admin-secret
     env:
       GF_EXPLORE_ENABLED: true
-      GF_SERVER_ROOT_URL: "https://grafana.${SECRET_DOMAIN}"
+      GF_SERVER_ROOT_URL: "https://grafana.${INTERNAL_DOMAIN}"
 
     dashboardProviders:
       dashboardproviders.yaml:
@@ -255,7 +255,7 @@ spec:
         allow_embedding: true
         cookie_samesite: grafana
       server:
-        root_url: https://grafana.${SECRET_DOMAIN}
+        root_url: https://grafana.${INTERNAL_DOMAIN}
 
     imageRenderer:
       enabled: true
@@ -303,12 +303,11 @@ spec:
 
     ingress:
       enabled: true
-      ingressClassName: nginx
+      ingressClassName: nginx-internal
       annotations:
-        external-dns.alpha.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
         hajimari.io/icon: simple-icons:grafana
       hosts:
-        - &host "grafana.${SECRET_DOMAIN}"
+        - &host "grafana.${INTERNAL_DOMAIN}"
       tls:
         - hosts:
             - *host


### PR DESCRIPTION
## Summary
Grafana's HelmRelease used \`ingressClassName: nginx\` and \`grafana.\${SECRET_DOMAIN}\`. On the WSL cluster \`SECRET_DOMAIN\` resolves to the public domain (\`tnwks.us\`) via \`cluster-secrets\`, so the ingress only matched on the public controller VIP (\`10.5.0.202\`) — which is intentionally **not** bridged to the LAN (that path is fronted by cloudflared). LAN clients hitting \`grafana.tnwks.local\` landed on the internal controller, found no matching rule, and got 404.

- Flip ingressClassName to \`nginx-internal\`
- Use \`grafana.\${INTERNAL_DOMAIN}\` (always \`tnwks.local\`) for the host and the matching tls entry
- Drop the \`external-dns.alpha.kubernetes.io/target\` annotation — no longer publishing a public record
- Flip \`GF_SERVER_ROOT_URL\` and \`server.root_url\` to \`INTERNAL_DOMAIN\` so generated links / OAuth redirects stay coherent

Affects both clusters since the HelmRelease is shared. Matches the pattern already used by qbittorrent / zwave-js-ui / jellyfin (all internal-only).

## Test plan
- [ ] Flux reconciles the HelmRelease cleanly
- [ ] \`kubectl get ingress -n monitoring grafana\` shows class \`nginx-internal\` and host \`grafana.tnwks.local\`
- [ ] \`curl -k -H "Host: grafana.tnwks.local" https://10.10.91.142/\` returns 302 to /login (was 404)