### PR TITLE
fix(frigate): update config to 0.14+ schema (alerts/detections + live.streams)

### DIFF
--- a/kubernetes/apps/production/frigate/app/resources/config.yml
+++ b/kubernetes/apps/production/frigate/app/resources/config.yml
@@ -36,9 +36,13 @@ record:
   retain:
     days: 2
     mode: active_objects
-  events:
+  alerts:
     retain:
-      default: 2
+      days: 2
+      mode: active_objects
+  detections:
+    retain:
+      days: 2
       mode: active_objects
 
 objects:
@@ -114,7 +118,8 @@ cameras:
       height: 360
       fps: 10
     live:
-      stream_name: frigate_sv3c_east_hq
+      streams:
+        main: frigate_sv3c_east_hq
 
   frigate_sv3c_west:
     ffmpeg:
@@ -129,7 +134,8 @@ cameras:
       height: 360
       fps: 10
     live:
-      stream_name: frigate_sv3c_west_hq
+      streams:
+        main: frigate_sv3c_west_hq
 
   frigate_reolink_south:
     ffmpeg:
@@ -144,7 +150,8 @@ cameras:
       height: 360
       fps: 10
     live:
-      stream_name: frigate_reolink_south_hq
+      streams:
+        main: frigate_reolink_south_hq
 
   frigate_amcrest_kitchen:
     ffmpeg:
@@ -159,7 +166,8 @@ cameras:
       height: 480
       fps: 10
     live:
-      stream_name: frigate_amcrest_kitchen_hq
+      streams:
+        main: frigate_amcrest_kitchen_hq
 
   frigate_amcrest_balc:
     ffmpeg:
@@ -174,7 +182,8 @@ cameras:
       height: 480
       fps: 10
     live:
-      stream_name: frigate_amcrest_balc_hq
+      streams:
+        main: frigate_amcrest_balc_hq
 
   frigate_loryta_pool:
     ffmpeg:
@@ -189,7 +198,8 @@ cameras:
       height: 480
       fps: 10
     live:
-      stream_name: frigate_loryta_pool_hq
+      streams:
+        main: frigate_loryta_pool_hq
 
   frigate_loryta_fdoor:
     ffmpeg:
@@ -204,7 +214,8 @@ cameras:
       height: 480
       fps: 10
     live:
-      stream_name: frigate_loryta_fdoor_hq
+      streams:
+        main: frigate_loryta_fdoor_hq
 
 
   # frigate_porch:


### PR DESCRIPTION
## Summary
The Frigate container is on \`0.17.0-rc1\`, which enforces the 0.14+ config schema. The committed \`config.yml\` still used 0.13-era keys, producing eight startup validation errors:

- \`record.retain\` (kept) + \`record.events\` (removed): events config split into \`record.alerts\` + \`record.detections\` in 0.14 to match the new review/alert/detection model
- \`cameras[].live.stream_name\` → \`cameras[].live.streams\` (now a dict mapping display label → go2rtc stream). Each camera migrated with \`main:\` as the only label, matching what the previous \`stream_name\` value pointed at

## Test plan
- [ ] Flux reconciles the configmap and the frigate pod restarts cleanly
- [ ] \`/api/config\` no longer reports the eight "Extra inputs are not permitted" errors
- [ ] Each affected camera ( sv3c_east, sv3c_west, reolink_south, amcrest_kitchen, amcrest_balc, loryta_pool, loryta_fdoor ) shows live preview in the UI