### PR TITLE
fix(frigate): drop record.retain (removed in 0.14)

### DIFF
--- a/kubernetes/apps/production/frigate/app/resources/config.yml
+++ b/kubernetes/apps/production/frigate/app/resources/config.yml
@@ -33,9 +33,6 @@ snapshots:
 
 record:
   enabled: true
-  retain:
-    days: 2
-    mode: active_objects
   alerts:
     retain:
       days: 2


### PR DESCRIPTION
## Summary
Frigate 0.14+ removed the top-level \`record.retain\` block entirely; retention is now expressed only via \`record.alerts.retain\` + \`record.detections.retain\` (already in place from #1233). Pod startup logged:

\`\`\`
Line #  : 36
Key     : record -> retain
Message : Extra inputs are not permitted
\`\`\`

Followup to #1233.

## Test plan
- [ ] Frigate pod starts without config-validation errors