### PR TITLE
fix(frigate): add startup probe so slow boot doesn't trip liveness

### DIFF
--- a/kubernetes/apps/production/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/production/frigate/app/helmrelease.yaml
@@ -54,8 +54,20 @@ spec:
                   timeoutSeconds: 1
                   failureThreshold: 3
               readiness: *probes
+              # FastAPI takes ~25s to come up (DB vacuum + detector init);
+              # without a startup probe the liveness window kills the pod
+              # mid-boot.
               startup:
-                enabled: false
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/version
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 5
+                  timeoutSeconds: 1
+                  failureThreshold: 30
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
## Summary
- Frigate 0.17rc1 takes ~25s to bring FastAPI up on :5001 (DB vacuum + detector init).
- With \`initialDelaySeconds=0\` + 3 failures × 10s, the liveness window kills the container mid-boot, and nginx returns HTTP 500 from \`/api/version\` because its \`/auth\` subrequest to FastAPI fails with 502.
- Adding a startup probe (5s × 30 = up to 150s) lets boot complete before liveness/readiness take over.

## Test plan
- [ ] Flux reconciles the HR.
- [ ] Pod reaches \`1/1 Running\` without CrashLoops.
- [ ] \`https://frigate.tnwks.local\` serves UI from LAN.

Note: a separate Coral TPU \`libedgetpu.so.1.0\` load failure is observed (USB device stuck at bootloader VID 1a6e:089a, hasn't re-enumerated to 18d1:9302). That's tracked separately — it doesn't crash the pod, only disables the detector.