### PR TITLE
fix(frigate): switch to CPU detector while Coral stays at bootloader VID

### DIFF
--- a/kubernetes/apps/production/frigate/app/resources/config.yml
+++ b/kubernetes/apps/production/frigate/app/resources/config.yml
@@ -14,10 +14,16 @@ mqtt:
 database:
   path: /data/frigate.db
 
+# Coral USB is connected via usbipd → Docker --device /dev/bus/usb, but
+# Talos has no udev so the device doesn't re-enumerate after libedgetpu's
+# firmware upload (stays at bootloader VID 1a6e:089a, never flips to
+# runtime 18d1:9302). That makes load_delegate("libedgetpu.so.1.0") fail,
+# the detector subprocess dies, and frigate's watchdog tears the whole
+# app down. Run on CPU until we move the Coral to bare-metal.
 detectors:
-  coral:
-    type: edgetpu
-    device: usb
+  cpu:
+    type: cpu
+    num_threads: 3
 
 ffmpeg:
   global_args: ["-hide_banner", "-loglevel", "warning"]


### PR DESCRIPTION
## Summary
- The Coral USB device is stuck at bootloader VID/PID \`1a6e:089a\` and never re-enumerates to runtime \`18d1:9302\` after \`libedgetpu\` uploads firmware. Talos containers have no udev to handle the re-enum, and the usbipd → WSL → Docker \`--device /dev/bus/usb\` chain doesn't surface it to the pod.
- \`load_delegate(\"libedgetpu.so.1.0\")\` fails, the detector subprocess dies, and frigate's own watchdog logs \`Detection appears to have stopped. Exiting Frigate...\` ~20s after start, taking the whole app down.
- Switching to a CPU detector keeps frigate running. Coral acceleration can come back once the device moves to a bare-metal node with udev (or we figure out a way to nudge re-enumeration through usbipd).

## Test plan
- [ ] Pod reaches \`1/1 Running\` and stays up.
- [ ] \`https://frigate.tnwks.local\` serves the UI from the LAN.
- [ ] Cameras with reachable RTSP show frames.