### PR TITLE
fix(frigate): re-enable Coral edgetpu detector after USB chain fix

### DIFF
--- a/kubernetes/apps/production/frigate/app/resources/config.yml
+++ b/kubernetes/apps/production/frigate/app/resources/config.yml
@@ -14,16 +14,10 @@ mqtt:
 database:
   path: /data/frigate.db
 
-# Coral USB is connected via usbipd → Docker --device /dev/bus/usb, but
-# Talos has no udev so the device doesn't re-enumerate after libedgetpu's
-# firmware upload (stays at bootloader VID 1a6e:089a, never flips to
-# runtime 18d1:9302). That makes load_delegate("libedgetpu.so.1.0") fail,
-# the detector subprocess dies, and frigate's watchdog tears the whole
-# app down. Run on CPU until we move the Coral to bare-metal.
 detectors:
-  cpu:
-    type: cpu
-    num_threads: 3
+  coral:
+    type: edgetpu
+    device: usb
 
 ffmpeg:
   global_args: ["-hide_banner", "-loglevel", "warning"]


### PR DESCRIPTION
## Summary
- Reverts the temporary CPU detector from PR #1236 now that the Coral USB chain is working end-to-end.
- The breakthrough: \`usbipd attach\` causes a USB reset, and the device transitions back to bootloader VID/PID \`1a6e:089a\` on the WSL side. WSL/Talos has no Edge TPU runtime to upload firmware, so it stays stuck. Letting Windows hold the Coral first (firmware loads natively, device sits at \`18d1:9302\`) and then \`bind --force\` + \`attach --wsl\` keeps the runtime VID inside WSL.
- Recreated worker-2 with the live runtime Coral so Docker's \`--device=/dev/bus/usb\` captures the correct device number; pod sees the Coral at \`/dev/bus/usb/002/003\`.

## Test plan
- [ ] Pod stays \`1/1 Running\` with the Coral detector enabled.
- [ ] Frigate logs no longer show \`Failed to load delegate from libedgetpu.so.1.0\`.
- [ ] \`docs/usb-passthrough.md\` follow-up: document the bootloader → runtime VID handling order so this isn't lost.