### PR TITLE
feat(wsl): add local-path-bulk SC on E: drive for frigate recordings

### DIFF
--- a/kubernetes/apps/kube-system/local-path-provisioner/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/local-path-provisioner/app/helmrelease.yaml
@@ -28,11 +28,33 @@ spec:
     helperImage:
       repository: public.ecr.aws/docker/library/busybox
       tag: latest
-    storageClass:
-      defaultClass: true
-    nodePathMap:
-      - node: DEFAULT_PATH_FOR_NON_LISTED_NODES
-        paths: ["/var/lib/rancher/k3s/storage"]
+    # Two StorageClasses on this cluster:
+    #   local-path       — default, on the Talos node container's overlay (C:)
+    #   local-path-bulk  — pinned to homelab-wsl-worker-2 with a bind-mount of
+    #                      Windows E: at /mnt/e for bulk video / archive PVCs.
+    # The chart treats `storageClassConfigs` as exclusive with the top-level
+    # `storageClass` block — only entries in the map are created.
+    storageClassConfigs:
+      local-path:
+        storageClass:
+          create: true
+          defaultClass: true
+          defaultVolumeType: hostPath
+          reclaimPolicy: Delete
+          volumeBindingMode: WaitForFirstConsumer
+        nodePathMap:
+          - node: DEFAULT_PATH_FOR_NON_LISTED_NODES
+            paths: ["/var/lib/rancher/k3s/storage"]
+      local-path-bulk:
+        storageClass:
+          create: true
+          defaultClass: false
+          defaultVolumeType: hostPath
+          reclaimPolicy: Delete
+          volumeBindingMode: WaitForFirstConsumer
+        nodePathMap:
+          - node: homelab-wsl-worker-2
+            paths: ["/mnt/e/k8s-storage"]
     # NOTE: Do not enable Flux variable substitution on this HelmRelease
     configmap:
       setup: |-

--- a/kubernetes/clusters/wsl/apps/production/frigate-ks.yaml
+++ b/kubernetes/clusters/wsl/apps/production/frigate-ks.yaml
@@ -4,6 +4,10 @@
 # homelab-wsl-worker-2, the node with the Coral TPU passed through via
 # --device=/dev/bus/usb. Without this, the upstream selector matches no
 # WSL node and the pod stays Pending.
+#
+# Also point the media PVC at local-path-bulk (E: drive on Windows,
+# bind-mounted into worker-2 at /mnt/e/k8s-storage) and size it for
+# real footage. Upstream MS-01 sticks with the shared default.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -28,3 +32,9 @@ spec:
           path: /spec/values/defaultPodOptions/nodeSelector
           value:
             kubernetes.io/hostname: homelab-wsl-worker-2
+        - op: replace
+          path: /spec/values/persistence/media/storageClass
+          value: local-path-bulk
+        - op: replace
+          path: /spec/values/persistence/media/size
+          value: 100Gi

--- a/kubernetes/clusters/wsl/cluster-settings.yaml
+++ b/kubernetes/clusters/wsl/cluster-settings.yaml
@@ -15,6 +15,13 @@ data:
   INTERNAL_DOMAIN: "tnwks.local"
 
   # Storage classes
+  #   local-path       — default, on the Talos node container's overlay (C:)
+  #   local-path-bulk  — pinned to homelab-wsl-worker-2, backed by Windows E:
+  #                      via a /mnt/e bind-mount. Used directly by apps that
+  #                      need real disk (e.g. frigate recordings); not yet
+  #                      wired into STORAGE_CLASS_BULK because flipping that
+  #                      variable would invalidate existing qbit/jellyfin
+  #                      PVCs (storageClassName is immutable).
   STORAGE_CLASS_DEFAULT: "local-path"
   STORAGE_CLASS_BULK: "local-path"
 

--- a/talos/wsl/recreate-worker-2.sh
+++ b/talos/wsl/recreate-worker-2.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Recreate homelab-wsl-worker-2 with USB device passthrough and the
+# /mnt/e bind-mount that backs the local-path-bulk StorageClass.
+#
+# Why this script exists: `talosctl cluster create` provisions Talos node
+# containers with a fixed config — no way to add --device or extra -v
+# flags. The validated workflow is to inspect the existing container,
+# capture its named volumes + env (six volumes hold /var, kubelet state,
+# /opt, /system/state, /etc/cni, /etc/kubernetes), then docker rm + run
+# with the same volumes plus the extra device/mount flags. Named volumes
+# survive `docker rm`, so PVC data, kubelet state, and the machine
+# config all carry over.
+#
+# See docs/usb-passthrough.md for the full chain
+# (Windows host → usbipd → WSL → Docker → Talos → pod).
+#
+# Idempotent: running this against an already-recreated worker just
+# reapplies the same flags. Drains the node first so pods relocate
+# cleanly; uncordons at the end.
+
+NAME=homelab-wsl-worker-2
+IMAGE=ghcr.io/siderolabs/talos:v1.13.2
+NETWORK=homelab-wsl
+IP=10.5.0.4
+
+# USB devices passed through from the WSL host. Coral TPU lands on the
+# whole /dev/bus/usb tree (its busid changes when firmware reloads); the
+# Z-Stick is a stable serial-by-id symlink.
+USB_DEVICES=(
+  --device=/dev/bus/usb
+  --device=/dev/serial/by-id/usb-0658_0200-if00
+)
+
+# Bulk storage backing for local-path-bulk StorageClass: Windows E:
+# drive surfaced into WSL via 9p drvfs at /mnt/e, then bind-mounted
+# straight into the Talos container so the local-path-provisioner
+# helper pod can mkdir under it.
+EXTRA_MOUNTS=(
+  -v /mnt/e/k8s-storage:/mnt/e/k8s-storage
+)
+
+if ! docker inspect "$NAME" >/dev/null 2>&1; then
+  echo "!! container $NAME not found — bring the cluster up first" >&2
+  exit 1
+fi
+
+echo ">> draining $NAME"
+kubectl cordon "$NAME"
+kubectl drain "$NAME" --ignore-daemonsets --delete-emptydir-data --force --timeout=120s || true
+
+echo ">> capturing current container config"
+SNAPSHOT=$(docker inspect "$NAME")
+
+# Build -v flags from the existing named volumes (preserves PVC data
+# and Talos state across the recreate).
+VOLUME_ARGS=$(echo "$SNAPSHOT" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)[0]
+for m in d["Mounts"]:
+    if m["Type"] == "volume":
+        name = m["Name"]
+        dest = m["Destination"]
+        print("-v " + name + ":" + dest)
+')
+
+# USERDATA is the base64-encoded machine config — must be preserved
+# verbatim, otherwise the node forgets its identity and re-bootstraps.
+read -r PLATFORM TALOSSKU TPATH USERDATA < <(echo "$SNAPSHOT" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)[0]
+env = {x.split("=",1)[0]: x.split("=",1)[1] for x in d["Config"]["Env"]}
+print(env["PLATFORM"], env["TALOSSKU"], env["PATH"], env["USERDATA"])
+')
+
+echo ">> stopping $NAME"
+docker stop "$NAME"
+echo ">> removing $NAME"
+docker rm "$NAME"
+
+echo ">> recreating $NAME with USB + bulk-storage mounts"
+# shellcheck disable=SC2086 # word-splitting on $VOLUME_ARGS is intentional
+docker run -d \
+  --name "$NAME" \
+  --hostname "$NAME" \
+  --privileged \
+  --read-only \
+  --restart no \
+  --shm-size 67108864 \
+  --memory 8589934592 \
+  --cpus 4 \
+  --security-opt seccomp=unconfined \
+  --security-opt label=disable \
+  --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+  --network "$NETWORK" \
+  --ip "$IP" \
+  --label org.opencontainers.image.source=https://github.com/siderolabs/talos \
+  --label talos.cluster.name=homelab-wsl \
+  --label talos.owned=true \
+  --label talos.type=worker \
+  --tmpfs /run \
+  --tmpfs /system \
+  --tmpfs /tmp \
+  $VOLUME_ARGS \
+  "${USB_DEVICES[@]}" \
+  "${EXTRA_MOUNTS[@]}" \
+  -e "PLATFORM=$PLATFORM" \
+  -e "TALOSSKU=$TALOSSKU" \
+  -e "PATH=$TPATH" \
+  -e "USERDATA=$USERDATA" \
+  "$IMAGE"
+
+echo ">> waiting for $NAME to come Ready"
+kubectl wait --for=condition=Ready "node/$NAME" --timeout=180s
+kubectl uncordon "$NAME"
+
+echo ">> done"
+docker ps --filter name="$NAME" --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'


### PR DESCRIPTION
## Summary
- Adds a second `local-path` StorageClass (`local-path-bulk`) pinned to `homelab-wsl-worker-2` → `/mnt/e/k8s-storage`, backed by Windows E: (387G free) instead of the Talos node container's overlay fs on C:.
- Patches the WSL frigate overlay to point `persistence.media` at the new SC and bumps it to 100Gi for real footage retention.
- Persists the worker-2 recreate script in repo (`talos/wsl/recreate-worker-2.sh`) — auto-discovers existing named volumes + USERDATA so PVC data and machine config survive the rebuild.

## Why
Frigate was recording to a 1Gi PVC on `local-path`, which lives in the Talos node container overlay (C:). C: was filling. E: has plenty of headroom and is already 9p-mounted into WSL.

`STORAGE_CLASS_BULK` left at `local-path` intentionally — flipping it would invalidate the existing `cephfs-hdd-subvolume*` PVCs in qbit/jellyfin (storageClassName is immutable). Frigate gets the bulk SC via WSL-only Kustomization patch; MS-01 path unaffected.

## Test plan
- [x] worker-2 recreated with /mnt/e bind-mount; `talosctl ls /mnt/e/k8s-storage` succeeds, USB devices still present
- [ ] Flux reconciles new SC; `kubectl get sc` shows `local-path-bulk`
- [ ] Existing 1Gi `frigate-media` PVC deleted so 100Gi PVC on `local-path-bulk` binds
- [ ] Frigate pod Running; recordings landing on E: