### PR TITLE
fix(cognito): require user verification when WebAuthn is a first-factor

### DIFF
--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -26,9 +26,11 @@ resource "aws_cognito_user_pool" "tnwks_auth" {
     enabled = true
   }
 
+  # user_verification must be "required" when MFA is on AND WebAuthn is an
+  # allowed first-auth-factor — otherwise a passkey wouldn't count as MFA.
   web_authn_configuration {
     relying_party_id  = "internal.tnwks.us"
-    user_verification = "preferred"
+    user_verification = "required"
   }
 
   # Allow passkey-only first-factor login in addition to password.
@@ -239,5 +241,5 @@ output "cognito_agent_client_secret" {
 
 output "cognito_hosted_ui_domain" {
   description = "Fully-qualified hosted UI domain."
-  value       = "${aws_cognito_user_pool_domain.tnwks_auth.domain}.auth.us-east-1.amazoncognito.com"
+  value       = "${aws_cognito_user_pool_domain.tnwks_auth.domain}.auth.${data.aws_region.current.name}.amazoncognito.com"
 }

--- a/infrastructure/terraform/aws/accounts/prod/main.tf
+++ b/infrastructure/terraform/aws/accounts/prod/main.tf
@@ -45,6 +45,7 @@ terraform {
 ## ---------------------------------------------------------------------------------------------------------------------
 
 data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
 data "sops_file" "secrets" {
   source_file = "secrets.sops.yaml"
 }


### PR DESCRIPTION
## Summary

The previous apply (#1245) errored with:

> InvalidParameterException: Cannot set WebAuthn factor configuration to SINGLE_FACTOR if MFA is required and WebAuthn is an allowed first auth factor.

Cognito only counts a passkey as multi-factor by itself when
`user_verification = "required"`. With `"preferred"` it's still possible
for the authenticator to skip the user-verification step, leaving the
passkey as a single factor — which contradicts `mfa_configuration = "ON"` +
`WEB_AUTHN` in `allowed_first_auth_factors`.

## What changed

- `cognito.tf`: `web_authn_configuration.user_verification` → `"required"`
- `cognito.tf`: `cognito_hosted_ui_domain` output now derives the region
  from `data.aws_region.current` instead of hardcoding `us-east-1` (the
  prod provider runs in **us-west-2** since SES lives there)
- `main.tf`: declare the missing `data "aws_region" "current"` source

## Cleanup note

The first apply made it past the user-pool create and into state before
the MFA call failed, so on next apply Terraform will issue an in-place
update instead of a re-create. The 7 remaining resources will be created
fresh.

## Test plan
- [ ] PR Terraform Plan shows: 1 to change (the user pool — MFA config), 7 to add, 0 to destroy
- [ ] Merge → apply succeeds
- [ ] `terraform output cognito_user_pool_endpoint` returns a us-west-2 issuer URL
- [ ] Hosted UI is reachable at `tnwks-auth.auth.us-west-2.amazoncognito.com`
- [ ] Create test user, register a passkey, sign in passwordless