### PR TITLE
fix(cognito): work around provider WebAuthn factor_configuration gap

### DIFF
--- a/infrastructure/terraform/aws/accounts/prod/COGNITO.md
+++ b/infrastructure/terraform/aws/accounts/prod/COGNITO.md
@@ -16,9 +16,10 @@ pool that backs authentication for `*.internal.tnwks.us` services
     `openid email profile`, with secret
   - `agent-ori` — client_credentials, scopes `tnwks-api/read`,
     `tnwks-api/write`, with secret
-- **Hosted UI domain:** prefix `tnwks-auth.auth.us-east-1.amazoncognito.com`
+- **Hosted UI domain:** prefix `tnwks-auth.auth.us-west-2.amazoncognito.com`
 - **MFA:** required, TOTP + WebAuthn passkeys; passwordless first-factor
-  login allowed
+  login allowed *(configured out-of-band — see [Enable MFA](#enable-mfa-one-time)
+  below)*
 - **Password policy:** 12+ chars, mixed case, numbers, symbols
 - **Token lifetimes:** access 24h, id 24h, refresh 30d
 - **Sign-up:** disabled (admin-create only)
@@ -36,6 +37,39 @@ pool that backs authentication for `*.internal.tnwks.us` services
 | `cognito_agent_client_id`             |            |
 | `cognito_agent_client_secret`         | sensitive  |
 | `cognito_hosted_ui_domain`            |            |
+
+## Enable MFA (one-time)
+
+Terraform creates the pool with `mfa_configuration = "OFF"` because the AWS
+provider's `web_authn_configuration` block is missing the `FactorConfiguration`
+field that AWS requires when WebAuthn is an allowed first-auth-factor — tracked
+in [hashicorp/terraform-provider-aws#47598](https://github.com/hashicorp/terraform-provider-aws/issues/47598).
+Run this once after the first apply:
+
+```bash
+POOL_ID="$(terraform output -raw cognito_user_pool_id)"
+
+aws cognito-idp set-user-pool-mfa-config \
+  --user-pool-id "$POOL_ID" \
+  --mfa-configuration ON \
+  --software-token-mfa-configuration Enabled=true \
+  --web-authn-configuration RelyingPartyId=internal.tnwks.us,UserVerification=required
+
+aws cognito-idp update-user-pool \
+  --user-pool-id "$POOL_ID" \
+  --policies '{
+    "SignInPolicy": {
+      "AllowedFirstAuthFactors": ["PASSWORD", "WEB_AUTHN"]
+    }
+  }'
+```
+
+The pool resource has `lifecycle.ignore_changes` on `mfa_configuration`,
+`software_token_mfa_configuration`, `web_authn_configuration`, and
+`sign_in_policy` so subsequent Terraform plans won't try to revert this.
+
+When the upstream provider gains `factor_configuration` support, fold these
+back into `cognito.tf` and drop the lifecycle ignores.
 
 ## Adding a user
 

--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -20,23 +20,12 @@ resource "aws_cognito_user_pool" "tnwks_auth" {
     temporary_password_validity_days = 7
   }
 
-  mfa_configuration = "ON"
-
-  software_token_mfa_configuration {
-    enabled = true
-  }
-
-  # user_verification must be "required" when MFA is on AND WebAuthn is an
-  # allowed first-auth-factor — otherwise a passkey wouldn't count as MFA.
-  web_authn_configuration {
-    relying_party_id  = "internal.tnwks.us"
-    user_verification = "required"
-  }
-
-  # Allow passkey-only first-factor login in addition to password.
-  sign_in_policy {
-    allowed_first_auth_factors = ["PASSWORD", "WEB_AUTHN"]
-  }
+  # MFA + WebAuthn + sign-in policy are configured out-of-band — see COGNITO.md.
+  # The provider's web_authn_configuration block is missing the FactorConfiguration
+  # field (hashicorp/terraform-provider-aws#47598), so AWS rejects every apply that
+  # tries to enable MFA with WebAuthn as a first-factor. Once that lands, fold these
+  # back into the resource and drop the lifecycle ignores below.
+  mfa_configuration = "OFF"
 
   account_recovery_setting {
     recovery_mechanism {
@@ -63,6 +52,15 @@ resource "aws_cognito_user_pool" "tnwks_auth" {
   }
 
   deletion_protection = "ACTIVE"
+
+  lifecycle {
+    ignore_changes = [
+      mfa_configuration,
+      software_token_mfa_configuration,
+      web_authn_configuration,
+      sign_in_policy,
+    ]
+  }
 }
 
 ## ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The first apply on PR #1245 and the follow-up on #1246 both errored with:

> InvalidParameterException: Cannot set WebAuthn factor configuration to SINGLE_FACTOR if MFA is required and WebAuthn is an allowed first auth factor.

Root cause: AWS Cognito's `SetUserPoolMfaConfig` API takes a
`FactorConfiguration` field on the WebAuthn block (values
`SINGLE_FACTOR` / `MULTI_FACTOR_WITH_USER_VERIFICATION`). The
`hashicorp/aws` provider's `web_authn_configuration` block doesn't expose
that argument — see [hashicorp/terraform-provider-aws#47598](https://github.com/hashicorp/terraform-provider-aws/issues/47598)
(open enhancement, no merged PR). Without that field the provider sends
`FactorConfiguration` unset, AWS defaults it to `SINGLE_FACTOR`, and any
combination of `mfa_configuration = "ON"` + `WEB_AUTHN` in
`allowed_first_auth_factors` is rejected.

## What changed

- `cognito.tf`: set `mfa_configuration = "OFF"`, removed the
  `software_token_mfa_configuration`, `web_authn_configuration`, and
  `sign_in_policy` blocks
- `cognito.tf`: added `lifecycle.ignore_changes` on those four fields so
  future plans don't try to revert the out-of-band configuration
- `COGNITO.md`: documented the one-time CLI commands required after
  apply to enable MFA + passkeys + passwordless sign-in
- `COGNITO.md`: fixed a stale `us-east-1` reference in the hosted UI
  description (we run in `us-west-2`)

## Manual step after apply

```bash
POOL_ID="$(terraform output -raw cognito_user_pool_id)"

aws cognito-idp set-user-pool-mfa-config \
  --user-pool-id "$POOL_ID" \
  --mfa-configuration ON \
  --software-token-mfa-configuration Enabled=true \
  --web-authn-configuration RelyingPartyId=internal.tnwks.us,UserVerification=required

aws cognito-idp update-user-pool \
  --user-pool-id "$POOL_ID" \
  --policies '{"SignInPolicy":{"AllowedFirstAuthFactors":["PASSWORD","WEB_AUTHN"]}}'
```

## Test plan
- [ ] PR plan shows: 1 to change (the orphan pool's MFA config back to OFF), 7 to add, 0 to destroy
- [ ] Apply succeeds
- [ ] Run the two AWS CLI commands above
- [ ] `aws cognito-idp describe-user-pool --user-pool-id $POOL_ID | jq '.UserPool | {MfaConfiguration, Policies.SignInPolicy}'` shows MFA ON + WebAuthn first factor
- [ ] Create test user, register passkey, sign in passwordless
- [ ] Subsequent `terraform plan` shows no drift (lifecycle ignores working)