### PR TITLE
feat(cognito): apply MFA + WebAuthn declaratively via terraform_data

### DIFF
--- a/infrastructure/terraform/aws/accounts/prod/COGNITO.md
+++ b/infrastructure/terraform/aws/accounts/prod/COGNITO.md
@@ -18,8 +18,8 @@ pool that backs authentication for `*.internal.tnwks.us` services
     `tnwks-api/write`, with secret
 - **Hosted UI domain:** prefix `tnwks-auth.auth.us-west-2.amazoncognito.com`
 - **MFA:** required, TOTP + WebAuthn passkeys; passwordless first-factor
-  login allowed *(configured out-of-band — see [Enable MFA](#enable-mfa-one-time)
-  below)*
+  login allowed *(applied via [terraform_data + AWS CLI](#mfa-configuration)
+  due to a provider gap)*
 - **Password policy:** 12+ chars, mixed case, numbers, symbols
 - **Token lifetimes:** access 24h, id 24h, refresh 30d
 - **Sign-up:** disabled (admin-create only)
@@ -38,38 +38,22 @@ pool that backs authentication for `*.internal.tnwks.us` services
 | `cognito_agent_client_secret`         | sensitive  |
 | `cognito_hosted_ui_domain`            |            |
 
-## Enable MFA (one-time)
+## MFA configuration
 
-Terraform creates the pool with `mfa_configuration = "OFF"` because the AWS
-provider's `web_authn_configuration` block is missing the `FactorConfiguration`
-field that AWS requires when WebAuthn is an allowed first-auth-factor — tracked
-in [hashicorp/terraform-provider-aws#47598](https://github.com/hashicorp/terraform-provider-aws/issues/47598).
-Run this once after the first apply:
+MFA + WebAuthn passkeys are enabled by `terraform_data.cognito_mfa` in
+`cognito.tf`, which calls `aws cognito-idp set-user-pool-mfa-config` via a
+local-exec provisioner. The CLI shell-out exists because the AWS provider's
+`web_authn_configuration` block is missing the `FactorConfiguration`
+argument that AWS requires when WebAuthn is a first-auth-factor — see
+[hashicorp/terraform-provider-aws#47598](https://github.com/hashicorp/terraform-provider-aws/issues/47598).
 
-```bash
-POOL_ID="$(terraform output -raw cognito_user_pool_id)"
+To change MFA settings (relying party ID, user verification, factor
+configuration), edit the `local.cognito_mfa` map in `cognito.tf` and apply.
+The trigger hash will fire the provisioner again.
 
-aws cognito-idp set-user-pool-mfa-config \
-  --user-pool-id "$POOL_ID" \
-  --mfa-configuration ON \
-  --software-token-mfa-configuration Enabled=true \
-  --web-authn-configuration RelyingPartyId=internal.tnwks.us,UserVerification=required
-
-aws cognito-idp update-user-pool \
-  --user-pool-id "$POOL_ID" \
-  --policies '{
-    "SignInPolicy": {
-      "AllowedFirstAuthFactors": ["PASSWORD", "WEB_AUTHN"]
-    }
-  }'
-```
-
-The pool resource has `lifecycle.ignore_changes` on `mfa_configuration`,
-`software_token_mfa_configuration`, `web_authn_configuration`, and
-`sign_in_policy` so subsequent Terraform plans won't try to revert this.
-
-When the upstream provider gains `factor_configuration` support, fold these
-back into `cognito.tf` and drop the lifecycle ignores.
+When the upstream provider gains `factor_configuration` support, fold the
+fields back into `aws_cognito_user_pool` and drop both the
+`terraform_data.cognito_mfa` resource and the lifecycle ignores.
 
 ## Adding a user
 

--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -20,12 +20,16 @@ resource "aws_cognito_user_pool" "tnwks_auth" {
     temporary_password_validity_days = 7
   }
 
-  # MFA + WebAuthn + sign-in policy are configured out-of-band — see COGNITO.md.
-  # The provider's web_authn_configuration block is missing the FactorConfiguration
-  # field (hashicorp/terraform-provider-aws#47598), so AWS rejects every apply that
-  # tries to enable MFA with WebAuthn as a first-factor. Once that lands, fold these
-  # back into the resource and drop the lifecycle ignores below.
+  # MFA + WebAuthn are configured by the terraform_data.cognito_mfa resource
+  # via SetUserPoolMfaConfig — the provider's web_authn_configuration block
+  # is missing the FactorConfiguration field
+  # (hashicorp/terraform-provider-aws#47598), so a native MFA apply is rejected
+  # by AWS. sign_in_policy stays here because the provider handles it safely.
   mfa_configuration = "OFF"
+
+  sign_in_policy {
+    allowed_first_auth_factors = ["PASSWORD", "WEB_AUTHN"]
+  }
 
   account_recovery_setting {
     recovery_mechanism {
@@ -58,8 +62,51 @@ resource "aws_cognito_user_pool" "tnwks_auth" {
       mfa_configuration,
       software_token_mfa_configuration,
       web_authn_configuration,
-      sign_in_policy,
     ]
+  }
+}
+
+## ---------------------------------------------------------------------------------------------------------------------
+## MFA CONFIGURATION
+## Workaround for hashicorp/terraform-provider-aws#47598 (provider's
+## web_authn_configuration block is missing the FactorConfiguration field).
+## Calls SetUserPoolMfaConfig via the AWS CLI on every change; that API only
+## mutates MFA-related fields, so it's safe to use without a read-modify-write.
+## On destroy, reverts MFA to OFF so deletion isn't blocked.
+##
+## TFC dynamic credentials inject AWS_ACCESS_KEY_ID/SECRET/SESSION_TOKEN into
+## the run env (TFC_AWS_PROVIDER_AUTH=true), which local-exec inherits.
+## ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  cognito_mfa = {
+    relying_party_id     = "internal.tnwks.us"
+    user_verification    = "required"
+    factor_configuration = "MULTI_FACTOR_WITH_USER_VERIFICATION"
+  }
+}
+
+resource "terraform_data" "cognito_mfa" {
+  triggers_replace = [
+    aws_cognito_user_pool.tnwks_auth.id,
+    local.cognito_mfa,
+  ]
+
+  provisioner "local-exec" {
+    when    = create
+    command = <<-EOT
+      set -euo pipefail
+      aws cognito-idp set-user-pool-mfa-config \
+        --user-pool-id ${aws_cognito_user_pool.tnwks_auth.id} \
+        --mfa-configuration ON \
+        --software-token-mfa-configuration Enabled=true \
+        --web-authn-configuration RelyingPartyId=${local.cognito_mfa.relying_party_id},UserVerification=${local.cognito_mfa.user_verification},FactorConfiguration=${local.cognito_mfa.factor_configuration}
+    EOT
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "aws cognito-idp set-user-pool-mfa-config --user-pool-id ${self.triggers_replace[0]} --mfa-configuration OFF"
   }
 }
 


### PR DESCRIPTION
## Summary

Replaces the manual post-apply runbook (added in #1247) with a declarative
`terraform_data` resource that shells out to `aws cognito-idp set-user-pool-mfa-config`
via `local-exec`. The CLI shell-out is still necessary because the AWS
provider's `web_authn_configuration` block is missing the
`FactorConfiguration` argument
([hashicorp/terraform-provider-aws#47598](https://github.com/hashicorp/terraform-provider-aws/issues/47598))
— but it now fires automatically whenever `local.cognito_mfa` changes,
no human in the loop.

## Why local-exec is safe here

`SetUserPoolMfaConfig` is a dedicated, narrow API — it only mutates MFA
fields. Unlike `UpdateUserPool` (full-replace, would clobber other config),
this one can be called blindly without a read-modify-write.

## What changed

- Added `local.cognito_mfa` with all the MFA inputs, and
  `terraform_data.cognito_mfa` with create/destroy provisioners
- Moved `sign_in_policy { allowed_first_auth_factors }` back into
  `aws_cognito_user_pool.tnwks_auth` (provider handles it correctly)
- Trimmed `lifecycle.ignore_changes` accordingly (kept `mfa_configuration`,
  `software_token_mfa_configuration`, `web_authn_configuration`; removed
  `sign_in_policy`)
- COGNITO.md: replaced the manual runbook with a short "MFA configuration"
  section explaining the provider gap and where to edit settings

## How auth works inside local-exec

The `aws_var_set` workspace varset has `TFC_AWS_PROVIDER_AUTH=true` and
`TFC_AWS_RUN_ROLE_ARN`, which makes TFC mint short-lived AWS creds and
inject them as `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN`
into the run environment. `local-exec` inherits those, so the CLI call
authenticates as the same role the provider uses.

## Plan expectations
- 1 to add (`terraform_data.cognito_mfa`)
- 1 to change (`aws_cognito_user_pool.tnwks_auth` — adds `sign_in_policy`)
- 0 to destroy

## Test plan
- [ ] Plan matches the expectation above
- [ ] Apply succeeds; provisioner output shows the MFA config + sign_in_policy were both applied
- [ ] `aws cognito-idp describe-user-pool --user-pool-id $POOL_ID | jq '.UserPool | {MfaConfiguration, Policies.SignInPolicy}'` shows MFA `ON` and `AllowedFirstAuthFactors=["PASSWORD","WEB_AUTHN"]`
- [ ] Subsequent `terraform plan` shows no drift
- [ ] Bumping `local.cognito_mfa.user_verification` to a different value re-fires the provisioner on next apply (manual sanity check, optional)