### PR TITLE
fix(cognito): drop bash-only pipefail from local-exec

### DIFF
--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -95,7 +95,7 @@ resource "terraform_data" "cognito_mfa" {
   provisioner "local-exec" {
     when    = create
     command = <<-EOT
-      set -euo pipefail
+      set -eu
       aws cognito-idp set-user-pool-mfa-config \
         --user-pool-id ${aws_cognito_user_pool.tnwks_auth.id} \
         --mfa-configuration ON \


### PR DESCRIPTION
## Summary

Apply on PR #1248 errored:

> /bin/sh: 1: set: Illegal option -o pipefail

TFC remote runners use `dash`, not `bash`. The provisioner died before the
AWS CLI ran. Switching to `set -eu` (no pipes anyway).

## Test plan
- [ ] Plan: 1 to add (terraform_data.cognito_mfa)
- [ ] Apply succeeds
- [ ] `aws cognito-idp describe-user-pool` shows MfaConfiguration=ON