### PR TITLE
feat(auth): add oauth2-proxy + Cognito-backed Grafana auth

### DIFF
--- a/kubernetes/apps/auth/kustomization.yaml
+++ b/kubernetes/apps/auth/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./oauth2-proxy/ks.yaml

--- a/kubernetes/apps/auth/namespace.yaml
+++ b/kubernetes/apps/auth/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: auth
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/auth/oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/oauth2-proxy/app/helmrelease.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: oauth2-proxy
+  namespace: auth
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: oauth2-proxy
+      version: 10.6.0
+      sourceRef:
+        kind: HelmRepository
+        name: oauth2-proxy
+        namespace: flux-system
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    replicaCount: 1
+    config:
+      clientID: ${OAUTH2_PROXY_CLIENT_ID}
+      clientSecret: ${OAUTH2_PROXY_CLIENT_SECRET}
+      cookieSecret: ${OAUTH2_PROXY_COOKIE_SECRET}
+      configFile: |-
+        provider = "oidc"
+        oidc_issuer_url = "${COGNITO_OIDC_ISSUER_URL}"
+        redirect_url = "https://oauth2.${INTERNAL_DOMAIN}/oauth2/callback"
+        upstreams = ["static://200"]
+        email_domains = ["*"]
+        scope = "openid email profile"
+        pass_access_token = true
+        pass_authorization_header = true
+        pass_user_headers = true
+        set_xauthrequest = true
+        set_authorization_header = true
+        reverse_proxy = true
+        whitelist_domains = [".${INTERNAL_DOMAIN}"]
+        cookie_domains = [".${INTERNAL_DOMAIN}"]
+        cookie_expire = "720h"
+        cookie_refresh = "23h"
+        cookie_secure = true
+        cookie_samesite = "lax"
+        skip_provider_button = true
+    extraArgs:
+      provider: oidc
+    ingress:
+      enabled: true
+      className: nginx-internal
+      hosts:
+        - oauth2.${INTERNAL_DOMAIN}
+      tls:
+        - hosts:
+            - oauth2.${INTERNAL_DOMAIN}
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 128Mi
+    metrics:
+      enabled: false

--- a/kubernetes/apps/auth/oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/auth/oauth2-proxy/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: auth
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/auth/oauth2-proxy/ks.yaml
+++ b/kubernetes/apps/auth/oauth2-proxy/ks.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: oauth2-proxy
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: ingress-nginx-internal
+  path: ./kubernetes/apps/auth/oauth2-proxy/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -8,6 +8,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./auth
   - ./cert-manager
   - ./databases
   - ./default

--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -256,6 +256,19 @@ spec:
         cookie_samesite: grafana
       server:
         root_url: https://grafana.${INTERNAL_DOMAIN}
+      auth.proxy:
+        enabled: true
+        header_name: X-Auth-Request-User
+        header_property: username
+        headers: "Email:X-Auth-Request-Email Groups:X-Auth-Request-Groups"
+        auto_sign_up: true
+        enable_login_token: true
+      auth:
+        # Keep local admin login as fallback while oauth2-proxy is being rolled out.
+        disable_login_form: false
+      users:
+        auto_assign_org: true
+        auto_assign_org_role: Admin
 
     imageRenderer:
       enabled: true
@@ -306,6 +319,9 @@ spec:
       ingressClassName: nginx-internal
       annotations:
         hajimari.io/icon: simple-icons:grafana
+        nginx.ingress.kubernetes.io/auth-url: "http://oauth2-proxy.auth.svc.cluster.local:80/oauth2/auth"
+        nginx.ingress.kubernetes.io/auth-signin: "https://oauth2.${INTERNAL_DOMAIN}/oauth2/start?rd=$scheme://$host$escaped_request_uri"
+        nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Groups,X-Auth-Request-Email"
       hosts:
         - &host "grafana.${INTERNAL_DOMAIN}"
       tls:

--- a/kubernetes/clusters/wsl/apps/kustomization.yaml
+++ b/kubernetes/clusters/wsl/apps/kustomization.yaml
@@ -24,6 +24,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   # Shared namespaces — used as-is
+  - ../../../apps/auth
   - ../../../apps/cert-manager
   - ../../../apps/databases
   - ../../../apps/default

--- a/kubernetes/clusters/wsl/cluster-secrets.sops.yaml
+++ b/kubernetes/clusters/wsl/cluster-secrets.sops.yaml
@@ -4,23 +4,30 @@ metadata:
     name: cluster-secrets
     namespace: flux-system
 stringData:
-    MAUBOT_ADMIN_PASSWORD: ENC[AES256_GCM,data:UlRNadAy/NX4PU4ffp3L6Ku7qwT4Pc8dL6+PhA==,iv:8sSD7DLBKJMAQnLtIfPTVFNERJBgt/6NOqJ9V4mKKwQ=,tag:Kvhpdjiim4lGJ/q2VEDJhQ==,type:str]
-    SECRET_DOMAIN: ENC[AES256_GCM,data:6UViELRkMc4=,iv:G+ZSUyRDp3hP4IQkLGUMS5U4qmL5hZqCJr71o/ZUYeM=,tag:qIf2QpM9XihzjLspXwaHmQ==,type:str]
-    SECRET_PREFIX: ENC[AES256_GCM,data:ZYBdWs6/j1fH,iv:17cxNJMMRWw/zBaJh/d/V6wxqECz0f1K2gbjwLzgnNs=,tag:HD+gQDwrTWY+LXAkrGlDLg==,type:str]
-    SECRET_ACME_EMAIL: ENC[AES256_GCM,data:MoO8ZUpq6opfROnzOe+cTw==,iv:Fpk0auCFpTfUKUFI8He9mpPE1xzvOkziq/EV0iAwfm0=,tag:nVj2ZH+80o1M4wN210Z7/A==,type:str]
-    SECRET_CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:kHOfY5dcrjuuC4kQ2jaHb4N7BoMvmUXiR/YTu7jMVkSgiYt5,iv:xAz+GqND4/8fCf5EDy1n9mmCdPAgr7o7ysKqBC9Kd60=,tag:NbrQuKIVuo1H9P7CFOQsEg==,type:str]
-    POSTGRES_USER: ENC[AES256_GCM,data:vjhd,iv:8wyVUALrQFjVq9rErjkkb/GIUijRQkUndb5ODh5tA/I=,tag:tCduAd/5gtcwsarvqCxS5Q==,type:str]
-    POSTGRES_PASSWORD: ENC[AES256_GCM,data:A/mL++Cp0CINJqjwZORn2fZ8epwTTulxNIZh6/iLk/9GtdP6clMILq+LMnIbjQpG3yt/eWYbXUXbFR+vtleZQw==,iv:Kvhi+4AnQu7I+B7yXYMWUcX8RuBPo2571QTRgHF1Fxs=,tag:pt9OHGMK9a1zbbbQ8CwqDQ==,type:str]
-    POSTGRES_SERVER: ENC[AES256_GCM,data:NQSZ53sv+HpNAQSpyq7B6x//PDKUiAwAEsqyDJFY5giVjxG1H3Jp,iv:khzCwxPR5FrgLZfXs5ucasVmDJjfi+CUGEskSYwXDdo=,tag:0oMKoVzQEMR4JlFvWCOXJQ==,type:str]
-    SMTP_USER: ENC[AES256_GCM,data:qwc0NbPG+oaOwit6cRybyqxrClM=,iv:hKy1qjXqETsRy5FNjstrPGRn2ihFNDvcNVabOpMdFjI=,tag:rmNWU25Ps11hP0WHk+ySDA==,type:str]
-    SMTP_PASSWORD: ENC[AES256_GCM,data:85JtyiLRmGAeO03pJAEMSiTRgMYCF9txnUHrlvCMbcnk9cdpXf3nI5sk7EU=,iv:0mDoVk6QRI7zup2SS5vhriV28bMaa71WHE2+PdV9WQM=,tag:K7vb1lmtW/K28jrEcujPTQ==,type:str]
-    TIMEZONE: ENC[AES256_GCM,data:JiB9l+FvwJY4ZrolJLm/Svdh5Q==,iv:O2KLNlxeIZjjWxMAQuFBp4W03amK65ILyb6gGfqs+pY=,tag:mE7OdQOTdB0iyrxl0fToGg==,type:str]
+    MAUBOT_ADMIN_PASSWORD: ENC[AES256_GCM,data:+G+MpUKzLSfjMqZte8cl/iIKdsWKzwZBm4NzEA==,iv:G1HZj5WLY1CqwQo0LFmvxq+1/eLpur0vA3GemUXdIts=,tag:tG8h466TmVPJcOUY5aXRuA==,type:str]
+    SECRET_DOMAIN: ENC[AES256_GCM,data:5aHspISsMi8=,iv:W8Xkfiq8oi0MnDemwuYDWI+2GRGqsOLL+iqrWeixN8w=,tag:7Cj1bEdkfciARlDzVaO95A==,type:str]
+    SECRET_PREFIX: ENC[AES256_GCM,data:eZTzyxlYKWzD,iv:XdneFIuvozn9SuXBWtVOMsGNlYfehq8dmVX7Y3tOZZQ=,tag:VssH0vXmNfhjKK4LDTIQtg==,type:str]
+    SECRET_ACME_EMAIL: ENC[AES256_GCM,data:YBfTUsaoa6WjRUvwb2KxNw==,iv:FXQtkNNQ+Qy0I3rWpz0YD1PmNizxJgJVseA29hpiL3k=,tag:FdauI0Venw+R6y2kE9g+xg==,type:str]
+    SECRET_CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:+hbbs/BDuD7Lua0Y4nyOrZXwLQZ7LNQSJuJTo/k6i7J3RBCc,iv:k3bA3vHHUUpD1v/RATmBjHBZ00TjEE+sLw6q4SReN3M=,tag:mgZ9lJ34Vf6cUZ5L3WsN9g==,type:str]
+    POSTGRES_USER: ENC[AES256_GCM,data:ZJ8O,iv:MrokGtI2PC+UMC728It3P8lHMmPH9z5UOU3QlmtanUg=,tag:Ghjp93wIpu52/wbqOPMe3A==,type:str]
+    POSTGRES_PASSWORD: ENC[AES256_GCM,data:Mxjz4LRzhzyCysYgciowe/Smd1eEwFhr7nmStkBhkM5mqMe1BPrUgrNVGRcJJFJtjO6DDrtM9opXuRZSlED6+g==,iv:rQYlsrOU/pmbKnvIlqFViqPcJU/onI2/u2mmtYfDo5A=,tag:y+zN0H2uPne7wSABx51izA==,type:str]
+    POSTGRES_SERVER: ENC[AES256_GCM,data:dwKrMOO5PS1t1yNC33Hr++GJKjLfWGJO6ihYnvWNM/yO91mRDGia,iv:3KpMAut0M53qEIZyeeBgq19/2zSGDb3XJQarbP/Plwc=,tag:ZHbyNKaBVIRxVyH5gO870Q==,type:str]
+    SMTP_USER: ENC[AES256_GCM,data:NyYSW7k+nE7+lLsd0HVMqETQpR4=,iv:6czaAHUhf+9V1nZjVaZ/GBS17zd5RDdxb8bk22GW/sA=,tag:zMNFTXKySERksfrCMte12g==,type:str]
+    SMTP_PASSWORD: ENC[AES256_GCM,data:Eaaoc65MBXiWDVcZOjmtKroOH1pi0JVu1oaQ2KnfFhcq+yAg4wx+nWDT2JM=,iv:8EBJV6p6D59eelkjYjaR46wzsjwKGoP9HPD4rHy+vj8=,tag:MQSzT/iddmxGumzm5EAQdA==,type:str]
+    TIMEZONE: ENC[AES256_GCM,data:FGBOitWRaZ8drBmt1Vw/x8TdIg==,iv:d/thWU3AMhDL0uSwQJZt4ewu7wcZSd9mXf6zjEAJL3A=,tag:i0GZ1uMny8UTLoG8hRo2sw==,type:str]
+    #ENC[AES256_GCM,data:USZzVNrJvsEviknJO8ovl3vfknB4/UA=,iv:b7LQgDMMRTEi5mS4psvAOp83I0P18G/JbqaK3UtszBs=,tag:HGfLOeysGmLnDlfiNjpI7Q==,type:comment]
+    COGNITO_REGION: ENC[AES256_GCM,data:H2+2MxP7+DW+,iv:bEx/lX3uSgqFskMwkbfLbYwMHmJYIHw2gRi3HvOo88Q=,tag:p2QT1SCqi4uVl1SJLbfuCA==,type:str]
+    COGNITO_USER_POOL_ID: ENC[AES256_GCM,data:52Hae4O55ap/XgsbNgVxAHk7Fg==,iv:Lf1+z+5M47X7yGfrSnT4Il1OHS4qDsLrcE2T/1U/h0k=,tag:Lp/U3U57cC39exhmYLtYOg==,type:str]
+    COGNITO_OIDC_ISSUER_URL: ENC[AES256_GCM,data:vikFDIlL0G+2JR8aFl7sI5Dy6P3zF2UI+lrmY5e68emRneV8QPxkvoUyTf17MUl/iN7fvZ+L3XEMwXm3aV8r,iv:Q3cwkVHbmjHaf85pdMoyANuUKzGjjwSDbyzc+vroDrc=,tag:7kgO9k2L9s5ga5bLQJ0JWA==,type:str]
+    OAUTH2_PROXY_CLIENT_ID: ENC[AES256_GCM,data:KLWN+n21j922UQ8MS4cuTryxPCu3BXzLrQ==,iv:Ks12P7KuqVjnEnxqK60b7r0CD+lnSDVJ4slNqtYR5HI=,tag:RVO+mVtOkdVKmDnQs0u0Ng==,type:str]
+    OAUTH2_PROXY_CLIENT_SECRET: ENC[AES256_GCM,data:KrQ9Ex2dTkBgp2YJj3br9+hRxrRNolfadnWGCSHU9ql26WRF0mjtLVfizW7gjLq8fxY2,iv:MxYCUgWVnZOWr1FUOCe+sw2NB+G3SqpQdyFjnQTdpaY=,tag:CiLgp3s0JsZp1gdvvbWVsA==,type:str]
+    OAUTH2_PROXY_COOKIE_SECRET: ENC[AES256_GCM,data:9mfYSl+KtEFAhSNfVHV9n6SzvNsgNT0oE4AR0wllWfGhFfk5Cfk+V7MGhFM=,iv:Uo+7fYKftWQHEWIWJWJjXk4DrzA4OcokonFKgwp+ZRs=,tag:YVPeTBO2rUnxj5RcGIXNtA==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-west-2:654654220436:key/mrk-74c4597ebffd41d38a852228e13d76cc
           role: arn:aws:iam::654654220436:role/iam-role-sops
-          created_at: "2026-05-24T15:55:44Z"
-          enc: AQICAHhNDAK0Is+rGNAlNYnav2FEvs37O7WQwrCmqkcTMDWNIQEy3tM3roQVS1MBI1IGuo7IAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMQVs6846dKg7/h1QiAgEQgDvhPr9h4zntznVYLzGiT5jP8UWRw6dtJlrFOOW4WB1Oq125am6P6kulWFVGo/n28hGlahdJFGrnLhQgEQ==
+          created_at: "2026-05-26T15:22:01Z"
+          enc: AQICAHhNDAK0Is+rGNAlNYnav2FEvs37O7WQwrCmqkcTMDWNIQF5IZvE9A4qKCsw0BP+4lE8AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMNvXwYAQK0C80WVcGAgEQgDuzk1N4fgG9n97R8H0g611ckA7UTOeyLuIYxPtkc5BVYx4p5a3Ek4VCN2UPvRjH45h15yR7VHnD+zzKqA==
           aws_profile: ""
     gcp_kms: []
     azure_kv: []
@@ -29,32 +36,32 @@ sops:
         - recipient: age1mzxwncaj0364q8jxfj0y73ptt63czwxucf9lrnn28c7kwyr5wfdsj9gsk2
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJSmk0WjNncG93L2xtUU1P
-            UExTUUZXdjVucEs4OXJaRWFsUm9lQ1dGWENJCmxTZm1VTU4zeVpWd3p2S3NEUE1X
-            QjlVa1hlUElUbitmRm0yMmZKNWJFblkKLS0tIHNjOFYzWWM2Q1ZCc3BaQmRiaGZl
-            RkJheUtrUWFHeHFTVDFlTUpXZUZEcVEKh8Z81agRpF9bZniFkSeqyf9KxxGXzCcp
-            pp7fk7wKrjZq1gOYAtK6qSViDha21DleN+PPsfkWlhg+QBwHjAQX3Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzck9zRlhpZFM1RThNaFlk
+            bE1rOEZXWitUdFZlK3VncUNQaFM0bVUxR1FJCk8yUElwRGlnNEpUWHQxdWE0T0d2
+            NnJxZ0dtcHJ6SUFhUFY5dnBuM3B5SVUKLS0tIFFJMmpQZWJEenB6VmJLcTJvbUZt
+            cmdMYkY2QlNON3Z4T0c3MlJHVk5yTWsKVBDOGgH/cUZSVBpQJIC8pMvmWdrff/rR
+            AG+6c/+fGl809QYDH9dY+L9dRzRajEFWYz4iU5sx5mw9OIOXC4WYeA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age12uckcdwv9p2s75ae3h20wgn70taatdzzl44n9x6vr8h9qurzkaqqkhphz7
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3WEk4bWNIcFBsSXR5UC9m
-            YnZHNXZRV0ZlOHhMOWJoVmR2Z2tBQ1BYMzNFCitKNElDN1FjcXcrOVcyVGhBdW1B
-            dXNreGc5c3pjcDNiUFRiZHd0YmJoZDgKLS0tIE5KeEFwaHdiR3E2MnFZQ0FDdEgx
-            UzFlWmF2MHRCTHl3T3lSSHhGNURKejgKLZUNyTSnacsTy2+KqU0ViQPO1pyzQUME
-            a0ecxSKoARLD03MFQZj4Jxcz0i9ftuLss+U+LO+bHUdoDNOH9TKkow==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4RXdWc3hqZm13UGJkOFo5
+            aG9heW5mZnpoWmFTaFJSNnZqN1FkaU5IcUZ3CklHRVVXek9BalVEWXlmakNRTFZO
+            WVR0RlMxQVFqcGYweDd2UjhJY0RTdHMKLS0tIC9LbUdQL0ozdktRdU9KeFFzclVi
+            WW04QjFSWHZFVG1TNkFWUi9jYlhFc0EKmI3grAllNwf8znZI4p33yFUJ3WgmWyMy
+            F6/e/CrgP+/KbatTG1CKJlA1jdT+rr2UlCAw3huL+JspzAq08le99A==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hmmuna95ktwl9sf9j56wjjukyf22ukdyjd8c47nlf5fjgyeyk5rsmhtyjx
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKclRBTUR0OW5PNFd0NUZK
-            eWRYdkFvSjRuNmdDREZNazhqRTQrZXgwSzNzCmhYQndkWFlOQmgvR3RkRkMxWi9n
-            cWp3dXZaQUpqZk1hc04yQ0RhdXdlY3cKLS0tIEtiUWttMGJ4Yng3WUhOanVOemw5
-            bmkxbkxtT21SUFZKbk8wMjczZVhSVlEKhqU0JcHyF+uSDDRcK2V2whB4vtjM0O+y
-            oZj8W/LEVWVeRb5zD139rrwOYMyWHo7VtukRFvdCJMyEznlDhe8I5A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBra1pFQnpSQXllVUdiWlNO
+            ZnJ5NzI4Rkl2VWRWeWJtdWxSbzJOQ3ZCRlRrCnptN0hKcVVaRjNlTWZhYmM1aTVW
+            TFE2M3FBODNPYVo1WHhSTGxOTWRGazAKLS0tIG1GV0pPMTViYUsvck1Md1JvZ2t3
+            b0RGN2FVemlCczBYM2tNOVBSVjNReGsKDxw/rd5IAYLEdfdgExFdb2S4B04uQbru
+            ZbqoeFxHMTM2uhR5QNSJN7lpIf5ygZg7RxdV3l+jV8BezuodvBQrsQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-25T00:09:48Z"
-    mac: ENC[AES256_GCM,data:NOQhLmmOChEY+57J/TfznsdoDEAUO+/clqf6TYPFV8hx+8IgdjWby5pYQPaVwWPFPfQQoid5pzrLNh/oTmOlXKo53US8cZdr+M0owWN3dFNHIvSPRSNdJrJdk1wnr2pOFxr+87mkjGvlCJK/mYYxv30raG1rmFpaatzuqi47Jnw=,iv:Zr1KjM4sP5TmQ/8OWCc4rYNnsjnEYdLx00HdCpeJ4E4=,tag:31ofnqWguODhN5q6ABhueA==,type:str]
+    lastmodified: "2026-05-26T15:22:02Z"
+    mac: ENC[AES256_GCM,data:cGrXv3qB65GucYhs69+oxvNMyg/mHmuFv61Z9ArDKdSQVTrF6HlAY/YYDegCCrGGumjh/ozelZRGQlA2qAzeBuHqEt8isg9Dic9AfuD1y5tO1hMjn5IV0pgOJlq8W30wuYfh5aR74VRlzMRkkj0dr9HSYYDCE6Qfn8iTLA0fvYY=,iv:awO5MaoADdTe7XIpmAWhn2CpJy8SjvX4TWBMWNJPBWc=,tag:bHFuRxyQ1iNSuiGUVopJFQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
-    version: 3.8.1
+    version: 3.7.3

--- a/kubernetes/flux/meta/helm/kustomization.yaml
+++ b/kubernetes/flux/meta/helm/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - ./metallb.yaml
   - ./metrics-server.yaml
   - ./node-feature-discovery.yaml
+  - ./oauth2-proxy.yaml
   - ./prometheus-community.yaml
   - ./stakater.yaml
   - ./weave-gitops.yaml

--- a/kubernetes/flux/meta/helm/oauth2-proxy.yaml
+++ b/kubernetes/flux/meta/helm/oauth2-proxy.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: oauth2-proxy
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://oauth2-proxy.github.io/manifests


### PR DESCRIPTION
## Summary
- Adds `oauth2-proxy` deployed in a new `auth` namespace, fronted by ingress-nginx-internal at `oauth2.${INTERNAL_DOMAIN}`. Provider is OIDC against the existing `tnwks-auth` Cognito user pool's `oauth2-proxy` app client.
- Wires Grafana ingress to use it via `nginx.ingress.kubernetes.io/auth-url`/`auth-signin`. Adds `auth.proxy` to grafana.ini, auto-assigns new SSO users to Admin (single-user homelab). Local login form left enabled as a fallback while we shake this down.
- Cognito client ID/secret, cookie secret, region, user-pool ID, and OIDC issuer URL added to `cluster-secrets.sops.yaml`. Internal domain continues to use the existing `INTERNAL_DOMAIN` ConfigMap var. Cognito region is `us-west-2` (the Terraform provider in `accounts/prod` happens to land there — outputs confirm).
- Adds the oauth2-proxy HelmRepository and registers the new `auth` namespace in both the shared apps overlay and the wsl cluster overlay.

## Notes / decisions
- Chart pinned to `oauth2-proxy/oauth2-proxy` v10.6.0 (latest at time of write).
- `upstreams = ["static://200"]` since this instance is only used as an auth subrequest, not as a forward proxy.
- `cookie_domains = [".${INTERNAL_DOMAIN}"]` so the cookie is shared across subdomains for future apps.
- `cookie_refresh = 23h` (just under the 24h access-token TTL) and `cookie_expire = 720h` (= refresh-token TTL of 30d).
- Depends on `ingress-nginx-internal` only; doesn't block other Kustomizations (`wait: false`).

## Test plan
- [ ] Flux reconciles `cluster-meta` (HelmRepository visible: `flux get sources helm -A | grep oauth2-proxy`)
- [ ] `kubectl get pods -n auth` shows oauth2-proxy running
- [ ] `kubectl get ingress -n auth oauth2-proxy` resolves to the internal LB and TLS comes up
- [ ] Visiting `https://grafana.internal.tnwks.us` redirects to Cognito hosted UI, login completes, lands back in Grafana with the user auto-provisioned as Admin
- [ ] Local-login fallback still works for `admin`