### PR TITLE
fix(auth): use 32-byte raw cookie secret for oauth2-proxy

### DIFF
--- a/kubernetes/clusters/wsl/cluster-secrets.sops.yaml
+++ b/kubernetes/clusters/wsl/cluster-secrets.sops.yaml
@@ -4,30 +4,30 @@ metadata:
     name: cluster-secrets
     namespace: flux-system
 stringData:
-    MAUBOT_ADMIN_PASSWORD: ENC[AES256_GCM,data:+G+MpUKzLSfjMqZte8cl/iIKdsWKzwZBm4NzEA==,iv:G1HZj5WLY1CqwQo0LFmvxq+1/eLpur0vA3GemUXdIts=,tag:tG8h466TmVPJcOUY5aXRuA==,type:str]
-    SECRET_DOMAIN: ENC[AES256_GCM,data:5aHspISsMi8=,iv:W8Xkfiq8oi0MnDemwuYDWI+2GRGqsOLL+iqrWeixN8w=,tag:7Cj1bEdkfciARlDzVaO95A==,type:str]
-    SECRET_PREFIX: ENC[AES256_GCM,data:eZTzyxlYKWzD,iv:XdneFIuvozn9SuXBWtVOMsGNlYfehq8dmVX7Y3tOZZQ=,tag:VssH0vXmNfhjKK4LDTIQtg==,type:str]
-    SECRET_ACME_EMAIL: ENC[AES256_GCM,data:YBfTUsaoa6WjRUvwb2KxNw==,iv:FXQtkNNQ+Qy0I3rWpz0YD1PmNizxJgJVseA29hpiL3k=,tag:FdauI0Venw+R6y2kE9g+xg==,type:str]
-    SECRET_CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:+hbbs/BDuD7Lua0Y4nyOrZXwLQZ7LNQSJuJTo/k6i7J3RBCc,iv:k3bA3vHHUUpD1v/RATmBjHBZ00TjEE+sLw6q4SReN3M=,tag:mgZ9lJ34Vf6cUZ5L3WsN9g==,type:str]
-    POSTGRES_USER: ENC[AES256_GCM,data:ZJ8O,iv:MrokGtI2PC+UMC728It3P8lHMmPH9z5UOU3QlmtanUg=,tag:Ghjp93wIpu52/wbqOPMe3A==,type:str]
-    POSTGRES_PASSWORD: ENC[AES256_GCM,data:Mxjz4LRzhzyCysYgciowe/Smd1eEwFhr7nmStkBhkM5mqMe1BPrUgrNVGRcJJFJtjO6DDrtM9opXuRZSlED6+g==,iv:rQYlsrOU/pmbKnvIlqFViqPcJU/onI2/u2mmtYfDo5A=,tag:y+zN0H2uPne7wSABx51izA==,type:str]
-    POSTGRES_SERVER: ENC[AES256_GCM,data:dwKrMOO5PS1t1yNC33Hr++GJKjLfWGJO6ihYnvWNM/yO91mRDGia,iv:3KpMAut0M53qEIZyeeBgq19/2zSGDb3XJQarbP/Plwc=,tag:ZHbyNKaBVIRxVyH5gO870Q==,type:str]
-    SMTP_USER: ENC[AES256_GCM,data:NyYSW7k+nE7+lLsd0HVMqETQpR4=,iv:6czaAHUhf+9V1nZjVaZ/GBS17zd5RDdxb8bk22GW/sA=,tag:zMNFTXKySERksfrCMte12g==,type:str]
-    SMTP_PASSWORD: ENC[AES256_GCM,data:Eaaoc65MBXiWDVcZOjmtKroOH1pi0JVu1oaQ2KnfFhcq+yAg4wx+nWDT2JM=,iv:8EBJV6p6D59eelkjYjaR46wzsjwKGoP9HPD4rHy+vj8=,tag:MQSzT/iddmxGumzm5EAQdA==,type:str]
-    TIMEZONE: ENC[AES256_GCM,data:FGBOitWRaZ8drBmt1Vw/x8TdIg==,iv:d/thWU3AMhDL0uSwQJZt4ewu7wcZSd9mXf6zjEAJL3A=,tag:i0GZ1uMny8UTLoG8hRo2sw==,type:str]
-    #ENC[AES256_GCM,data:USZzVNrJvsEviknJO8ovl3vfknB4/UA=,iv:b7LQgDMMRTEi5mS4psvAOp83I0P18G/JbqaK3UtszBs=,tag:HGfLOeysGmLnDlfiNjpI7Q==,type:comment]
-    COGNITO_REGION: ENC[AES256_GCM,data:H2+2MxP7+DW+,iv:bEx/lX3uSgqFskMwkbfLbYwMHmJYIHw2gRi3HvOo88Q=,tag:p2QT1SCqi4uVl1SJLbfuCA==,type:str]
-    COGNITO_USER_POOL_ID: ENC[AES256_GCM,data:52Hae4O55ap/XgsbNgVxAHk7Fg==,iv:Lf1+z+5M47X7yGfrSnT4Il1OHS4qDsLrcE2T/1U/h0k=,tag:Lp/U3U57cC39exhmYLtYOg==,type:str]
-    COGNITO_OIDC_ISSUER_URL: ENC[AES256_GCM,data:vikFDIlL0G+2JR8aFl7sI5Dy6P3zF2UI+lrmY5e68emRneV8QPxkvoUyTf17MUl/iN7fvZ+L3XEMwXm3aV8r,iv:Q3cwkVHbmjHaf85pdMoyANuUKzGjjwSDbyzc+vroDrc=,tag:7kgO9k2L9s5ga5bLQJ0JWA==,type:str]
-    OAUTH2_PROXY_CLIENT_ID: ENC[AES256_GCM,data:KLWN+n21j922UQ8MS4cuTryxPCu3BXzLrQ==,iv:Ks12P7KuqVjnEnxqK60b7r0CD+lnSDVJ4slNqtYR5HI=,tag:RVO+mVtOkdVKmDnQs0u0Ng==,type:str]
-    OAUTH2_PROXY_CLIENT_SECRET: ENC[AES256_GCM,data:KrQ9Ex2dTkBgp2YJj3br9+hRxrRNolfadnWGCSHU9ql26WRF0mjtLVfizW7gjLq8fxY2,iv:MxYCUgWVnZOWr1FUOCe+sw2NB+G3SqpQdyFjnQTdpaY=,tag:CiLgp3s0JsZp1gdvvbWVsA==,type:str]
-    OAUTH2_PROXY_COOKIE_SECRET: ENC[AES256_GCM,data:9mfYSl+KtEFAhSNfVHV9n6SzvNsgNT0oE4AR0wllWfGhFfk5Cfk+V7MGhFM=,iv:Uo+7fYKftWQHEWIWJWJjXk4DrzA4OcokonFKgwp+ZRs=,tag:YVPeTBO2rUnxj5RcGIXNtA==,type:str]
+    MAUBOT_ADMIN_PASSWORD: ENC[AES256_GCM,data:ct0bGKe9n2XrGhc4uGPF6/G/7tdMO7g38jhhtg==,iv:EbQ5YmE+APpJlhE7IjB9MscGLsvgQJwQ8rifyIA5YDA=,tag:NvITevo8u65DoSV6dkV7yA==,type:str]
+    SECRET_DOMAIN: ENC[AES256_GCM,data:EN+EoISJV4c=,iv:KbOVmA+FJTAkWp82CekhYd/wXD8A2RoXrjYE0D+jnrA=,tag:KG6snpUA/C/VRF0zRcm83w==,type:str]
+    SECRET_PREFIX: ENC[AES256_GCM,data:8xbNnjosoCTM,iv:CA+6V96NwPTIHUtuf1Stvmp7TxGJ62j5RJefA/xTTts=,tag:uDh6O6Y8llvmCrCYesRLDg==,type:str]
+    SECRET_ACME_EMAIL: ENC[AES256_GCM,data:U5XV2iIKBZTrAC7/4Yn/Cw==,iv:+YlEj6p+kztX940GgTi3Tnr1d0eTa8MZvpREG38j/rw=,tag:mS4bvwfmUNZ1Mv8/T10qug==,type:str]
+    SECRET_CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:kHUK/ThRNocJq5TTzdRqX5sdpAcYVyDiZA9eGCyz02GbDyp8,iv:tRCe+YxnAVGXcPUMW5IcHouBqI5C/LYF9197SlinGC4=,tag:wMaoVH8M2sQPi2huXqS2Ag==,type:str]
+    POSTGRES_USER: ENC[AES256_GCM,data:/X6B,iv:PnC4r2LkaR0km9YId4zwNQlFOfvI0C1DdCkfloMUNm8=,tag:Q2GSVPddmePJ/WsVZMNiZQ==,type:str]
+    POSTGRES_PASSWORD: ENC[AES256_GCM,data:laL+mQ8oQonzdsOs1OfbPVbR3/QYpVZXAaG+CNTWB6ysSUoMfU2MKlASq7VID+dimFvLXiT/FyY7s1QRqtN7Rw==,iv:oVejOrETpyfNKpdoCLoONCExsg2Ns+YMmpf8ZAuuFfk=,tag:6bSrN6UddpMhbqj9QbNgeA==,type:str]
+    POSTGRES_SERVER: ENC[AES256_GCM,data:dGh4JK5Lrv0NnU1HOmnc08TalOq+P7Nx/1dUwI7nelBa1hMYhMWu,iv:prYjj2TghEzB7ATyiAeSItrD7tgOQbSz0ZfWi/EkGFw=,tag:lsPT1V556uYWSbKK7Z3vTQ==,type:str]
+    SMTP_USER: ENC[AES256_GCM,data:Mp1KpjKll2RuEirlgT00lEJmRrQ=,iv:AukJTLVS4S5McCCJFiCalpewmXIVjScuLxiTkrw18WU=,tag:Cufvci/DDAdDh3MePAeRww==,type:str]
+    SMTP_PASSWORD: ENC[AES256_GCM,data:nHntPT72eRsfvrenou069sNWo1HSIR9hhwmg+dBAxZofah+yA15Gk0uIUe8=,iv:sDIQzMbxsWaMyk1nRAFFgInk5XGihSOIjguFgcH1LDg=,tag:n9fu/a+WpmiQiC5/KGm9zg==,type:str]
+    TIMEZONE: ENC[AES256_GCM,data:/sajfowJMxgdSn9AhclNWbB3kg==,iv:QFB6MTvREyqBDO0tNKdKw2/+oCJKde1bCyCSpFAILs0=,tag:6Zlr963rfWFDDkGXWo2OIg==,type:str]
+    #ENC[AES256_GCM,data:jl3Qajq6fF89CWE4vIZ/xCaM3Q5h36o=,iv:uCEDuyRhBZzdpRYYoPEECDvDrHDIWk3PXH6IvkiZkDA=,tag:lbuXIiSodnsauK9WLFD3jA==,type:comment]
+    COGNITO_REGION: ENC[AES256_GCM,data:M+1DPaLzt8M6,iv:2o5bOkFlod1BUL3InbSqWOCOkc55HjR/KKULUNx36f8=,tag:3Ik1ImSP11KgveseKwaWHQ==,type:str]
+    COGNITO_USER_POOL_ID: ENC[AES256_GCM,data:N/VW9/pLVgV77SrPk0WsPflTtg==,iv:pylkgmG4bEMhwPjDETxVCiT8Laq4BfSY3UnEh9fsOfI=,tag:aycPWeF98vRIghisDAMWeQ==,type:str]
+    COGNITO_OIDC_ISSUER_URL: ENC[AES256_GCM,data:KTFNmSQnabu4PCd547QsjiPcbmU/tAclTteioWdVy/Mi1ChKa8tMiaQy9i4W8PKIjP/NyTh/wLtgDxKRilbU,iv:Cc2S+QK6ya2T5btPMZcYKFSeXg8VY0sPLzrd3RDfNuA=,tag:QRa+0kB8YAR2kcDINs54SA==,type:str]
+    OAUTH2_PROXY_CLIENT_ID: ENC[AES256_GCM,data:eWzE26fTwybotZSDer5Bpf2Ix3jb5HNFhw==,iv:TvDISMU1OPSCSNIadUXtFLG0voScuCfnBO9XQr5e4t8=,tag:9FUqjh5SCY8QxmLI8MNHWA==,type:str]
+    OAUTH2_PROXY_CLIENT_SECRET: ENC[AES256_GCM,data:c3dx4IuXA77yhU2plla4mvvoVeGyR3BCvx7WzgwM9iZtLjCOEHp8sqU4V7y7fwR0jfG1,iv:0CUjX/CLK+poCtccoh/dbGaCdgf0mNk2WRAb8+KKA+s=,tag:ri55gapEmDgvtPd7UhIuRg==,type:str]
+    OAUTH2_PROXY_COOKIE_SECRET: ENC[AES256_GCM,data:aNpszQWcf0faovolEhG0Co5N4dQYd0njuhOig5imrRA=,iv:j+EqCHvaI4lpaBpSrHwOeu1bzNfrwnrkaSKzRy17L8w=,tag:h52zDWcDqjz1wWqffK0/+A==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-west-2:654654220436:key/mrk-74c4597ebffd41d38a852228e13d76cc
           role: arn:aws:iam::654654220436:role/iam-role-sops
-          created_at: "2026-05-26T15:22:01Z"
-          enc: AQICAHhNDAK0Is+rGNAlNYnav2FEvs37O7WQwrCmqkcTMDWNIQF5IZvE9A4qKCsw0BP+4lE8AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMNvXwYAQK0C80WVcGAgEQgDuzk1N4fgG9n97R8H0g611ckA7UTOeyLuIYxPtkc5BVYx4p5a3Ek4VCN2UPvRjH45h15yR7VHnD+zzKqA==
+          created_at: "2026-05-26T15:29:32Z"
+          enc: AQICAHhNDAK0Is+rGNAlNYnav2FEvs37O7WQwrCmqkcTMDWNIQGDo4hWVRTpAmvZ7FhP+WplAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMC8bwCXVU8vfghWYlAgEQgDvBWWMnHo8m5/JRCMHsadKXeef7XsP++cI+omIY2wdQGqUPZ/pRQdz0cKG7xohNEQ16Y/YXcWvSVUwXOg==
           aws_profile: ""
     gcp_kms: []
     azure_kv: []
@@ -36,32 +36,32 @@ sops:
         - recipient: age1mzxwncaj0364q8jxfj0y73ptt63czwxucf9lrnn28c7kwyr5wfdsj9gsk2
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzck9zRlhpZFM1RThNaFlk
-            bE1rOEZXWitUdFZlK3VncUNQaFM0bVUxR1FJCk8yUElwRGlnNEpUWHQxdWE0T0d2
-            NnJxZ0dtcHJ6SUFhUFY5dnBuM3B5SVUKLS0tIFFJMmpQZWJEenB6VmJLcTJvbUZt
-            cmdMYkY2QlNON3Z4T0c3MlJHVk5yTWsKVBDOGgH/cUZSVBpQJIC8pMvmWdrff/rR
-            AG+6c/+fGl809QYDH9dY+L9dRzRajEFWYz4iU5sx5mw9OIOXC4WYeA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyN2JEbW5nRTQzZGdvelky
+            NHNJc3NibTQ1WW1nVHJlQVEyclh5a3ZLWWdVCm02M3RRSHBjTXVXQ1dLT09rWG1E
+            UEw0UGwyUTd3NG9RMEVNdm9CcmxlQkUKLS0tIFo0ZE14QVJHdjJ4emdTUldQSmVJ
+            Y0RRSWhhTHVVM0F0Y1RzdW53NDJXUFUKamUN4dB8Ps3a1XWCTn9MuTvh0U8VabIZ
+            vLBrNXPcQ0eocy+94BhRN4lax37ikfsDTrljCVQZJtaIhF/uQrlQbg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age12uckcdwv9p2s75ae3h20wgn70taatdzzl44n9x6vr8h9qurzkaqqkhphz7
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4RXdWc3hqZm13UGJkOFo5
-            aG9heW5mZnpoWmFTaFJSNnZqN1FkaU5IcUZ3CklHRVVXek9BalVEWXlmakNRTFZO
-            WVR0RlMxQVFqcGYweDd2UjhJY0RTdHMKLS0tIC9LbUdQL0ozdktRdU9KeFFzclVi
-            WW04QjFSWHZFVG1TNkFWUi9jYlhFc0EKmI3grAllNwf8znZI4p33yFUJ3WgmWyMy
-            F6/e/CrgP+/KbatTG1CKJlA1jdT+rr2UlCAw3huL+JspzAq08le99A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBueXdzTzc3VGs1SUVHQUI1
+            NXNGb0hGWWVJbHV1eTB3a2E4WnZzUktzcm4wClRFVyttTUNBWHZrckU4eGZUYkRU
+            aFk5Q0ZuZ25JbnB0cG94V3lBNW1HRFEKLS0tIFBBVmdIWjFxUko4UDdJTnJHNTRx
+            NU50cVBnT04zSkFlMGNWT0FRWWNnWnMKBcXFPWTh/U7TdGYkJ5SMRShLz9JktSlJ
+            pOcxYYREsb2H1KJn+UNSC7yPwfaUq8GUQ4SXvRMyyIOPYXyjWmJcrA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hmmuna95ktwl9sf9j56wjjukyf22ukdyjd8c47nlf5fjgyeyk5rsmhtyjx
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBra1pFQnpSQXllVUdiWlNO
-            ZnJ5NzI4Rkl2VWRWeWJtdWxSbzJOQ3ZCRlRrCnptN0hKcVVaRjNlTWZhYmM1aTVW
-            TFE2M3FBODNPYVo1WHhSTGxOTWRGazAKLS0tIG1GV0pPMTViYUsvck1Md1JvZ2t3
-            b0RGN2FVemlCczBYM2tNOVBSVjNReGsKDxw/rd5IAYLEdfdgExFdb2S4B04uQbru
-            ZbqoeFxHMTM2uhR5QNSJN7lpIf5ygZg7RxdV3l+jV8BezuodvBQrsQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYTUJYemJ3Y2loU25XTVVm
+            SlY3U0VqaDhtTDMxdDdoNkc4WWRTcGhtVUZzCkgxY1RWZmZ1bktYZUVFZlllMVNL
+            bk5oU0dnK2t4U0JDYjdFVk52N0ZOVzQKLS0tIFBDdEFqTmgvVlNqZjBGSzk0SlFj
+            anpGNVNVUnlFd25NM0p1K1hyQ0tVUHMKWcNZhAcocdX+/RDQtjCccPd7z061mF3c
+            Z+8nJPQwQOWdaBeFd+8ZaZ54CM4HrzV6Cmy0VNGsezEpF8w+YCjmTg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-26T15:22:02Z"
-    mac: ENC[AES256_GCM,data:cGrXv3qB65GucYhs69+oxvNMyg/mHmuFv61Z9ArDKdSQVTrF6HlAY/YYDegCCrGGumjh/ozelZRGQlA2qAzeBuHqEt8isg9Dic9AfuD1y5tO1hMjn5IV0pgOJlq8W30wuYfh5aR74VRlzMRkkj0dr9HSYYDCE6Qfn8iTLA0fvYY=,iv:awO5MaoADdTe7XIpmAWhn2CpJy8SjvX4TWBMWNJPBWc=,tag:bHFuRxyQ1iNSuiGUVopJFQ==,type:str]
+    lastmodified: "2026-05-26T15:29:33Z"
+    mac: ENC[AES256_GCM,data:maMdv7GVp5D7e4Jc21Nc7C0fow9AbKKz2qagKtdG79FCFWdnSdUMPYJvybE5RBZz63Wn5Ppi+HLHrjiGk+t+82Ba5K6Oz8iL3xwfkJvd09bGP/XXOo5IfljRPM0T7gLqpQNR7+j8iCvICqhDtiUXVj/ZXbr/YC2+PdgvDr4GZ0M=,iv:WXZ1GYfrcl5fk0bjxSTIRDMYd7H8zV5jmntvU7HM6Pw=,tag:tr3KsYY104Yig1rgO5oSVQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.7.3


### PR DESCRIPTION
oauth2-proxy rejected the previous 44-byte (base64) cookie secret at startup. Replaced with a 32-byte raw string.