### PR TITLE
feat(cognito): create admin user via terraform

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -24,6 +24,12 @@ creation_rules:
       age12uckcdwv9p2s75ae3h20wgn70taatdzzl44n9x6vr8h9qurzkaqqkhphz7,
       age1hmmuna95ktwl9sf9j56wjjukyf22ukdyjd8c47nlf5fjgyeyk5rsmhtyjx
     kms: 'arn:aws:kms:us-west-2:654654220436:key/mrk-74c4597ebffd41d38a852228e13d76cc+arn:aws:iam::654654220436:role/iam-role-sops'
+  - path_regex: infrastructure/terraform/.*\.sops\.ya?ml
+    age: >-
+      age1mzxwncaj0364q8jxfj0y73ptt63czwxucf9lrnn28c7kwyr5wfdsj9gsk2,
+      age12uckcdwv9p2s75ae3h20wgn70taatdzzl44n9x6vr8h9qurzkaqqkhphz7,
+      age1hmmuna95ktwl9sf9j56wjjukyf22ukdyjd8c47nlf5fjgyeyk5rsmhtyjx
+    kms: 'arn:aws:kms:us-west-2:654654220436:key/mrk-74c4597ebffd41d38a852228e13d76cc+arn:aws:iam::654654220436:role/iam-role-sops'
   - path_regex: packer/.*\.sops\.ya?ml
     age: >-
       age1mzxwncaj0364q8jxfj0y73ptt63czwxucf9lrnn28c7kwyr5wfdsj9gsk2,

--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -121,7 +121,7 @@ resource "terraform_data" "cognito_mfa" {
   }
 
   provisioner "local-exec" {
-    when = destroy
+    when    = destroy
     command = <<-EOT
       set -eu
       creds=$(aws sts assume-role \
@@ -163,6 +163,31 @@ resource "aws_cognito_user_group" "agents" {
   user_pool_id = aws_cognito_user_pool.tnwks_auth.id
   description  = "Machine-to-machine clients"
   precedence   = 20
+}
+
+## ---------------------------------------------------------------------------------------------------------------------
+## USERS
+## Human admin(s). Email is sourced from secrets.sops.yaml so the value
+## doesn't land in the public repo. Cognito sends an invitation email on
+## create (admin_create_user_config -> allow_admin_create_user_only = true).
+## ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_cognito_user" "admin" {
+  user_pool_id = aws_cognito_user_pool.tnwks_auth.id
+  username     = data.sops_file.secrets.data["admin_email"]
+
+  attributes = {
+    email          = data.sops_file.secrets.data["admin_email"]
+    email_verified = true
+  }
+
+  desired_delivery_mediums = ["EMAIL"]
+}
+
+resource "aws_cognito_user_in_group" "admin_in_admins" {
+  user_pool_id = aws_cognito_user_pool.tnwks_auth.id
+  group_name   = aws_cognito_user_group.admins.name
+  username     = aws_cognito_user.admin.username
 }
 
 ## ---------------------------------------------------------------------------------------------------------------------

--- a/infrastructure/terraform/aws/accounts/prod/secrets.sops.yaml
+++ b/infrastructure/terraform/aws/accounts/prod/secrets.sops.yaml
@@ -1,12 +1,13 @@
-ses_domain: ENC[AES256_GCM,data:CnB63+Mvdt8=,iv:Y/D9FTBv7lcaae2uh/xMBPSx1mWNwfZT/lNRTat+v+M=,tag:Ye5RQO7DXS/wLmdraoTKTA==,type:str]
-smtp_username: ENC[AES256_GCM,data:pW7Zlwoh4hlS5HsgM786zi8Nb6A=,iv:qacoamBvVf85DwQbbvSPLDBVTjxNMvgsqdqG+lINSS8=,tag:rv8NdWS9djRAVCuzrq7Tmg==,type:str]
-smtp_password: ENC[AES256_GCM,data:NMxo1w5K5az0dIpJmQLIC5GYBUircXArbvT1pn809VxhHDrCVRQJfF6efJI=,iv:sOXinW1Fg/IT/HLpMQVfGjtkUq+xAKf9KwSmMpB+prs=,tag:tomgDo49tgOwclH4j1yRKg==,type:str]
+ses_domain: ENC[AES256_GCM,data:oh6+CPwYihE=,iv:CJb68N6knVR/iriISSBfpNF0LklUCdiewVHLmDWVHSw=,tag:3kt76lvBm0aGvNSKaFNo2w==,type:str]
+smtp_username: ENC[AES256_GCM,data:UnF6ay7rDYH3DVXPOTEFAqHOPsM=,iv:GUtXTkJ3tJIvfDA3R/3hajucpd7XqRPfDr3D3PnYFxs=,tag:Sz9iNk3+GPNdM7ug41BH4w==,type:str]
+smtp_password: ENC[AES256_GCM,data:xr1fYWm8MEy/8sAJjAoRDGjh0zACf7JvX86M2PhuTBcwQxODIxTns4y/tjQ=,iv:uo7XdyVxDoQVcg91p02KO4f1HciR09q0i5tx/7VllQY=,tag:S1fIWP+TeAqoi9SN8UDgsg==,type:str]
+admin_email: ENC[AES256_GCM,data:6MVcLaRLOSclyapz1oQ9VOOdhPtDI99wBQ==,iv:WMiRMJAugEqHCa9mztJDuw/iBzqmbWqzHJ3SHvYbRcg=,tag:Q0oQpIOhAOE6cW72F4Hs/A==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-west-2:654654220436:key/mrk-74c4597ebffd41d38a852228e13d76cc
           role: arn:aws:iam::654654220436:role/iam-role-sops
-          created_at: "2026-05-24T15:56:37Z"
-          enc: AQICAHhNDAK0Is+rGNAlNYnav2FEvs37O7WQwrCmqkcTMDWNIQH6Z0561s039jjetEOp4W+TAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMapDYfQrGtLL+nCUzAgEQgDt2c/8Fq4JU3i3MGGNZMJPIwOra5RoAp1dSh43VWUeOvaAUQGpsruDJMc2rzaSesF12FFT7MEaM7JdKAQ==
+          created_at: "2026-05-26T15:39:00Z"
+          enc: AQICAHhNDAK0Is+rGNAlNYnav2FEvs37O7WQwrCmqkcTMDWNIQEqE7Ejxya4tWZ85fnNBUH8AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMzPJny8yIvSJoE4MMAgEQgDvDAwpok12j5zfhbTE9w86KBsbvPQsEJ5CPDRupHXisOffFlcnx45gchERw1h7msCcCzAkna3YIAU2j+Q==
           aws_profile: ""
     gcp_kms: []
     azure_kv: []
@@ -15,32 +16,32 @@ sops:
         - recipient: age1mzxwncaj0364q8jxfj0y73ptt63czwxucf9lrnn28c7kwyr5wfdsj9gsk2
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDN2hFQ1FKOFRXTTA4cjg2
-            TE1odjNSai9neHdlZllXS1hjMm9rbytYbkdrCmNEamZyeHV1VGRZbngxd25vclc0
-            dGhzTVkwYU55cmRqbmJ4eGliT210U1EKLS0tIG9hZG5FbHpkdFlsRzBQeFMvcGhs
-            ZCtZY1JJd2w4SWpMeGJFTitsOHFlUmsKMeNv/40Xlw/e5NnrH6VKp7r0EoKuNy8I
-            tA/QMUnrVPxyN0XZSSk+Fj11YyrAtP76+GZscX6uDcW7MTO7MWu1gA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2dGhlRmNNTGVmeEpSRGxW
+            Wk9RUUdzeVhkaDRwV25qaUtSRGkzSzNxbW5RCjBlbERPTnB3SXl6WDJ2elIvRTNU
+            QWs3STVlWUxLcXh2ZVFNQmVrQmt5aG8KLS0tIDhTRlE4eVp0ODN4bG1oc210dERS
+            d3Y1Yjdia2ZXSDZSSG1Ya2UvVVVCTEEKMVJFF6nRTRMAcdwRj7OmBkLC5oxOF4kq
+            24VlyOGfBqYC6xPIxxnyA2QmYju7v9PCg6Y26tuQQVe2FltUCKHViw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age12uckcdwv9p2s75ae3h20wgn70taatdzzl44n9x6vr8h9qurzkaqqkhphz7
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkSSs2dTMzclJRNkVzdFQw
-            RVBadnUrN2hGYU9MOFFKWEVncWpnRDVvY1NZCmg3WkhlSDhFWklYa0pWRGFjdzdy
-            SVhJQ2hqcHRUVVBZSXZ3R3ZEb0xhb3cKLS0tIDZMYU40OGhmdXFGTFIvSUZEUEFL
-            NE9OdzUrampjUlhWbU5YZG03Z2VGMncKE6lmpALlXfW2WgpQDAQKVDsSWTKHV5Og
-            zIKdC4auMKrWWWl7jk1fho1p8Ppve+pR4MJLkQa0bW+6BuujMLFwJA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUVTJmaWtOLzFyRnRYMVg3
+            cC9KQ3ZZblI2N2J3MHNVNXI0U0NXbVRGSkZJCk1yNHJueCtvRUZqb3NHYVNuWkZT
+            SE9ia0Y3d3dnTGVGMUtzbGhwaCtmY0kKLS0tIEJVYVhyNHN4TmVsTFVmR1Y0K0FV
+            OWRsR3RqSlFveWNtd2FRWHVxajFGL2sKlJ0I30k3REJuA376nR2tQDrArMnrbhV2
+            lQ/+ajNG/qb6gosy3/+NZajn6n/D1JL2ewni6bSOjp2H/8tJQnt+NA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hmmuna95ktwl9sf9j56wjjukyf22ukdyjd8c47nlf5fjgyeyk5rsmhtyjx
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1SGQwUUlZVGFKQ1dvMll2
-            ZGM0SjFPc0tCWGJJNjN3OVpyc01GbGY2TFVZCjI0eTlHWTlPNGgvTVFORUpqeHpx
-            YXFsMFpZY3haRlpQMHEzbXFPZDVnVGcKLS0tIHVNTTE0YmNGVFdrTFhmcVYrMStW
-            cEh3NThIYzdxVW9ZUjdabGwvWUIvMW8KhxtOLKEtu8iiLoC/abgXylW5kqfyf8Re
-            M0S5p5oR9iC4f4kIZdLJYgvWk7dFWS2fxB8rbCePPm8HPs5pv4xvgQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMU3VrSDlWTHdJSTRhRG8v
+            WUMvNmVBcDBVVjBZTWlIdUhYV0hPOVdtdlQ0Ck9zZTgwVVhjbVBzL2g4Nis0U25m
+            ajBCeUFUSTRSRzRMaDlJNmxQNFNERGsKLS0tIFloc0x4bmNDV1dqSlIrZDBmVG52
+            empQYkRVeWdjWHB1djVqcDlQTkZjV28KXZ/+sLAJW8DtVFs3l0fyBK2YamMZFIZS
+            2hRpHpGNtq1vruXuOxhfhHX0GyDqZgWVh3q/Vdl3S+qe0ArE57gRBg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-01-16T03:09:53Z"
-    mac: ENC[AES256_GCM,data:7I19zEHghGrPjj9Dk5WAtQzORGZvTUgIVxurjwJIAR3Io0Rv2k9DqWSGqSRFe0WhPDStaG3IKbu1OAYFc5LCZELL28sJURpJct6uK/lWI23NYOUyGFEzwFFmBGfWyjVQwEcHo+P8izkJI/4bZiYAYUv34CaNqDmh9n8O7lHS7Xs=,iv:WNYmQrGqUwKAyX58JyH6AcC4Wp5X6+v4FgaoCH1g2pk=,tag:2R/675VWACZls17+hVHjSw==,type:str]
+    lastmodified: "2026-05-26T15:39:00Z"
+    mac: ENC[AES256_GCM,data:uc63Cmcu4NZjUZ5mWoK2IPbVD9Rta/aA4rJRZuenVtkCQmGcDxp5sJM3bhmzSPPt+FBo0J+GrJvr8XDuJqnuGKDeOekrE9vuoLk2aCjhRBSEXTjwJpwy1Yb7xBiW4rzt5Abg0rBxT6IFm85kYBCerwSX8f9+8ESFJYR1KbG32Y4=,iv:8pX0WlfrtlWniB6Nmbcvnv+wZIkkDTLRkrvtLg50qG8=,tag:P1vafI++XRTnlz0fskHnUQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3


### PR DESCRIPTION
## Summary
- Adds \`aws_cognito_user.admin\` + \`aws_cognito_user_in_group.admin_in_admins\` for the human admin (Ivan).
- Email is read from \`infrastructure/terraform/aws/accounts/prod/secrets.sops.yaml\` (\`admin_email\` key) so the address doesn't land in the public repo.
- Adds a sops creation rule for \`infrastructure/terraform/**.sops.yaml\` to \`.sops.yaml\` (the existing file pre-dated that path; it decrypted via metadata but couldn't be re-encrypted without a matching rule).

## Notes
- \`allow_admin_create_user_only = true\` on the pool means Cognito sends an invitation email on apply with a temporary password.
- Group \`admins\` already exists (precedence 1).
- \`email_verified = true\` is set so the user can log in immediately without an email click-through.

## Test plan
- [ ] TFC plan shows: 1 to add (\`aws_cognito_user.admin\`), 1 to add (\`aws_cognito_user_in_group.admin_in_admins\`); no destructive changes.
- [ ] Apply succeeds; invitation email lands.
- [ ] Sign in via \`https://grafana.internal.tnwks.us\` -> Cognito hosted UI -> back to Grafana, auto-provisioned as Admin.