### PR TITLE
fix(cognito): supply temporary password for admin user

### DIFF
--- a/infrastructure/terraform/aws/accounts/prod/.terraform.lock.hcl
+++ b/infrastructure/terraform/aws/accounts/prod/.terraform.lock.hcl
@@ -44,3 +44,24 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -168,13 +168,30 @@ resource "aws_cognito_user_group" "agents" {
 ## ---------------------------------------------------------------------------------------------------------------------
 ## USERS
 ## Human admin(s). Email is sourced from secrets.sops.yaml so the value
-## doesn't land in the public repo. Cognito sends an invitation email on
-## create (admin_create_user_config -> allow_admin_create_user_only = true).
+## doesn't land in the public repo.
+##
+## Pool's sign_in_policy enables PASSWORD as a first-auth factor, so
+## AdminCreateUser requires a TemporaryPassword (AWS won't generate one
+## itself). We hand in a random_password — the user changes it on first
+## login. The temp password is in TF state only; not output.
 ## ---------------------------------------------------------------------------------------------------------------------
 
+resource "random_password" "admin_temp" {
+  length           = 24
+  special          = true
+  override_special = "!@#$%^&*()-_=+"
+
+  # Rotate the temp password whenever the username changes (e.g. a new
+  # admin), but keep it stable otherwise so re-applies don't flap.
+  keepers = {
+    username = data.sops_file.secrets.data["admin_email"]
+  }
+}
+
 resource "aws_cognito_user" "admin" {
-  user_pool_id = aws_cognito_user_pool.tnwks_auth.id
-  username     = data.sops_file.secrets.data["admin_email"]
+  user_pool_id       = aws_cognito_user_pool.tnwks_auth.id
+  username           = data.sops_file.secrets.data["admin_email"]
+  temporary_password = random_password.admin_temp.result
 
   attributes = {
     email          = data.sops_file.secrets.data["admin_email"]
@@ -182,6 +199,12 @@ resource "aws_cognito_user" "admin" {
   }
 
   desired_delivery_mediums = ["EMAIL"]
+
+  # On re-applies the user has already rotated this password; don't
+  # try to reset it back to the temp value.
+  lifecycle {
+    ignore_changes = [temporary_password]
+  }
 }
 
 resource "aws_cognito_user_in_group" "admin_in_admins" {

--- a/infrastructure/terraform/aws/accounts/prod/main.tf
+++ b/infrastructure/terraform/aws/accounts/prod/main.tf
@@ -35,6 +35,10 @@ terraform {
       source  = "carlpett/sops"
       version = "~> 1.4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
   }
 }
 


### PR DESCRIPTION
Fixes apply failure on PR #1254. The pool requires PASSWORD as a first-auth factor, so AdminCreateUser rejects users without a temporary password. Generate one via random_password and ignore_changes after first login.