### PR TITLE
feat(cognito): make WebAuthn a first-auth factor (passwordless biometric)

### DIFF
--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -80,9 +80,12 @@ resource "aws_cognito_user_pool" "tnwks_auth" {
 
 locals {
   cognito_mfa = {
-    relying_party_id     = "internal.tnwks.us"
-    user_verification    = "required"
-    factor_configuration = "MULTI_FACTOR_WITH_USER_VERIFICATION"
+    relying_party_id  = "internal.tnwks.us"
+    user_verification = "required"
+    # ONLY_USER_VERIFICATION makes WebAuthn a first-auth factor (passwordless,
+    # one-step biometric). The PASSWORD path in sign_in_policy still requires
+    # TOTP MFA via this pool's mfa_configuration=ON + software_token_mfa.
+    factor_configuration = "ONLY_USER_VERIFICATION"
   }
 
   # Same role the AWS provider assumes in main.tf — TFC dynamic credentials


### PR DESCRIPTION
## Summary
- Flips Cognito WebAuthn from MFA second-factor to passwordless first-factor (`FactorConfiguration: ONLY_USER_VERIFICATION`).
- A passkey alone satisfies sign-in — one biometric prompt, no password, no second factor.
- The PASSWORD path still requires TOTP MFA (pool-level `mfa_configuration=ON` + `software_token_mfa` are unchanged), so the password fallback stays two-factor.

## Test plan
- [ ] TFC apply succeeds in `tnwks-ops-aws-prod`
- [ ] Sign in to https://grafana.internal.tnwks.us with email + password — Managed Login should prompt to enroll a passkey after the TOTP step
- [ ] Enroll passkey, sign out
- [ ] On a new device, Managed Login presents "Sign in with passkey" as a first-class option — biometric only completes auth
- [ ] Password fallback still requires TOTP