### PR TITLE
fix(cognito): use SINGLE_FACTOR for WebAuthn first-factor

### DIFF
--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -82,10 +82,12 @@ locals {
   cognito_mfa = {
     relying_party_id  = "internal.tnwks.us"
     user_verification = "required"
-    # ONLY_USER_VERIFICATION makes WebAuthn a first-auth factor (passwordless,
-    # one-step biometric). The PASSWORD path in sign_in_policy still requires
-    # TOTP MFA via this pool's mfa_configuration=ON + software_token_mfa.
-    factor_configuration = "ONLY_USER_VERIFICATION"
+    # SINGLE_FACTOR makes WebAuthn a first-auth factor (passwordless, one-step
+    # biometric). The PASSWORD path in sign_in_policy still requires TOTP MFA
+    # via this pool's mfa_configuration=ON + software_token_mfa.
+    # (The other valid value is MULTI_FACTOR_WITH_USER_VERIFICATION, which
+    # makes WebAuthn act as a second factor instead.)
+    factor_configuration = "SINGLE_FACTOR"
   }
 
   # Same role the AWS provider assumes in main.tf — TFC dynamic credentials


### PR DESCRIPTION
## Summary
- The prior PR apply errored: `SetUserPoolMfaConfig` only accepts `MULTI_FACTOR_WITH_USER_VERIFICATION` or `SINGLE_FACTOR` for `webAuthnConfiguration.factorConfiguration`. `ONLY_USER_VERIFICATION` is invalid.
- `SINGLE_FACTOR` is the correct value to make WebAuthn a passwordless first-factor.
- ⚠ The errored apply ran the destroy provisioner first, so the pool currently has `mfa_configuration=OFF`. This apply re-enables MFA + TOTP alongside the new WebAuthn config.

## Test plan
- [ ] TFC apply succeeds
- [ ] Pool MFA is back to ON (`aws cognito-idp describe-user-pool ... | jq .UserPool.MfaConfiguration`)
- [ ] Sign-in works: password + TOTP for fallback path; passkey alone for biometric path