### PR TITLE
feat(cognito): enable ALLOW_USER_AUTH on oauth2-proxy client for passkey enrollment

### DIFF
--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -257,8 +257,13 @@ resource "aws_cognito_user_pool_client" "oauth2_proxy" {
 
   generate_secret = true
 
-  callback_urls = ["https://oauth2.internal.tnwks.us/oauth2/callback"]
-  logout_urls   = ["https://oauth2.internal.tnwks.us/oauth2/sign_out"]
+  # Second callback_url is the post-enrollment landing for the
+  # /passkeys/add managed-login flow.
+  callback_urls = [
+    "https://oauth2.internal.tnwks.us/oauth2/callback",
+    "https://grafana.internal.tnwks.us/",
+  ]
+  logout_urls = ["https://oauth2.internal.tnwks.us/oauth2/sign_out"]
 
   allowed_oauth_flows                  = ["code"]
   allowed_oauth_flows_user_pool_client = true
@@ -266,7 +271,11 @@ resource "aws_cognito_user_pool_client" "oauth2_proxy" {
 
   supported_identity_providers = ["COGNITO"]
 
+  # ALLOW_USER_AUTH enables choice-based auth, which is the only flow that
+  # supports passkeys per AWS docs. ALLOW_USER_SRP_AUTH stays as the OIDC
+  # path oauth2-proxy uses today.
   explicit_auth_flows = [
+    "ALLOW_USER_AUTH",
     "ALLOW_USER_SRP_AUTH",
     "ALLOW_REFRESH_TOKEN_AUTH",
   ]


### PR DESCRIPTION
## Summary
- Per AWS docs, passkey support requires the *choice-based* authentication flow, which is gated behind `ALLOW_USER_AUTH` on the app client. Without it, the hosted `/passkeys/add` URL doesn't function.
- Adds `https://grafana.internal.tnwks.us/` as a second callback_url so post-enrollment redirect has a clean landing.
- Existing OIDC path is unchanged.

## Test plan
- [ ] TFC apply succeeds
- [ ] Visit `https://tnwks-auth.auth.us-west-2.amazoncognito.com/passkeys/add?client_id=8grd4d0tai42386feaj8ml5gk&redirect_uri=https%3A%2F%2Fgrafana.internal.tnwks.us%2F` while signed in
- [ ] Browser prompts for biometric / passkey enrollment
- [ ] Subsequent Grafana sign-in offers "Sign in with passkey" alongside password