### PR TITLE
fix(cognito): switch user pool domain to Managed Login v2

### DIFF
--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -416,6 +416,12 @@ resource "aws_cognito_user_pool_client" "agent_ori" {
 resource "aws_cognito_user_pool_domain" "tnwks_auth" {
   domain       = "tnwks-auth"
   user_pool_id = aws_cognito_user_pool.tnwks_auth.id
+
+  # version 2 = Managed Login (newer hosted UI, supports passkey enrollment
+  # at /passkeys/add). version 1 = classic Hosted UI which doesn't have
+  # the passkey endpoints — /passkeys/add returns "URL doesn't exist on the
+  # authorization server" without this.
+  managed_login_version = 2
 }
 
 ## ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `/passkeys/add` is a Managed-Login-only endpoint and 404s on classic Hosted UI domains.
- Sets `managed_login_version = 2` on the domain so the new endpoints (and the new login UX) are actually served.
- Branding alone (PR #1258) doesn't flip the domain — the domain has to be on v2 too.

## Test plan
- [ ] TFC apply succeeds
- [ ] Visiting Grafana shows the Managed Login UI (newer styling, button-style "Sign in with passkey")
- [ ] `/passkeys/add` URL no longer 404s