### PR TITLE
feat(cognito): add us-east-1 ACM cert for auth.tnwks.us [1/4]

### DIFF
--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -409,6 +409,41 @@ resource "aws_cognito_user_pool_client" "agent_ori" {
 }
 
 ## ---------------------------------------------------------------------------------------------------------------------
+## ACM CERT (us-east-1) for custom Cognito hosted-UI domain
+## auth.tnwks.us — Cognito custom domains require the cert to live in us-east-1
+## regardless of the user pool's region. Validation goes through Cloudflare DNS;
+## the validation CNAMEs are exposed via outputs and added in the cloudflare TF
+## workspace in a follow-up PR. Once validated, a separate PR replaces the
+## prefix-domain aws_cognito_user_pool_domain with the custom-domain version.
+## ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_acm_certificate" "auth_tnwks_us" {
+  provider          = aws.us_east_1
+  domain_name       = "auth.tnwks.us"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+output "auth_acm_certificate_arn" {
+  description = "ARN of the us-east-1 ACM cert for auth.tnwks.us. Consumed by aws_cognito_user_pool_domain in a follow-up apply."
+  value       = aws_acm_certificate.auth_tnwks_us.arn
+}
+
+output "auth_acm_validation_records" {
+  description = "DNS validation CNAMEs to add in the cloudflare workspace so ACM can issue the cert."
+  value = [
+    for o in aws_acm_certificate.auth_tnwks_us.domain_validation_options : {
+      name  = o.resource_record_name
+      type  = o.resource_record_type
+      value = o.resource_record_value
+    }
+  ]
+}
+
+## ---------------------------------------------------------------------------------------------------------------------
 ## HOSTED UI DOMAIN (prefix)
 ## tnwks-auth.auth.us-east-1.amazoncognito.com
 ## ---------------------------------------------------------------------------------------------------------------------

--- a/infrastructure/terraform/aws/accounts/prod/main.tf
+++ b/infrastructure/terraform/aws/accounts/prod/main.tf
@@ -10,6 +10,17 @@ provider "aws" {
   }
 }
 
+# Cognito custom domains require the ACM cert to be in us-east-1 regardless
+# of where the user pool actually lives (ours is us-west-2). Aliased provider
+# scoped to us-east-1 just for that ACM resource.
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+  assume_role {
+    role_arn = "arn:aws:iam::654654262098:role/tnwks-org-init-role"
+  }
+}
+
 ## ---------------------------------------------------------------------------------------------------------------------
 ## TERRAFORM
 ## Contains the configuration for Terraform Cloud, along with the required providers.


### PR DESCRIPTION
## Summary
Step 1 of 4 to move Cognito hosted login from the AWS prefix domain to a custom domain at `auth.tnwks.us`. Motivation: WebAuthn RPID needs to be `tnwks.us` so passkeys enrolled at the hosted login work for both internal and any future public services.

This PR only creates the ACM cert (us-east-1, required by Cognito) and exposes validation CNAMEs as outputs. No Cognito-domain changes yet — cert sits in `PENDING_VALIDATION` until PR2 adds the Cloudflare CNAMEs.

## Plan (for context)
1. **This PR** — AWS: us-east-1 provider alias + ACM cert + outputs
2. PR2 — Cloudflare: add apex `tnwks.us` placeholder A + ACM validation CNAMEs (copied from this PR's outputs)
3. PR3 — AWS: `acm_certificate_validation` + flip `aws_cognito_user_pool_domain` to custom-domain form + RPID change to `tnwks.us`
4. PR4 — Cloudflare: final `auth.tnwks.us` → CloudFront CNAME (copied from PR3 outputs)

## Test plan
- [ ] TFC apply succeeds
- [ ] `terraform output auth_acm_validation_records` returns the validation CNAME name+value pair
- [ ] Cert state in ACM is `PENDING_VALIDATION` (expected until PR2 lands)