### PR TITLE
chore(cloudflare): match deprecated minify=off so plans converge

### DIFF
--- a/infrastructure/terraform/modules/cloudflare/main.tf
+++ b/infrastructure/terraform/modules/cloudflare/main.tf
@@ -32,10 +32,13 @@ resource "cloudflare_zone_settings_override" "cloudflare_settings" {
     security_level = "medium"
     # /speed/optimization
     brotli = "on"
+    # Cloudflare deprecated Auto Minify in Aug 2024; the API still reports the
+    # field but Cloudflare flipped it off out-of-band. Match reality so plans
+    # don't keep trying to push it back on.
     minify {
-      css  = "on"
-      js   = "on"
-      html = "on"
+      css  = "off"
+      js   = "off"
+      html = "off"
     }
     rocket_loader = "on"
     # /caching/configuration


### PR DESCRIPTION
## Summary
- Cloudflare deprecated Auto Minify in Aug 2024 and flipped the toggle off across all 4 zones; the API still reports the field, so TF kept planning to push it back on.
- Set the module default to off to match reality and stop drift in every plan.

## Test plan
- [x] terraform plan in `infrastructure/terraform/cloudflare` no longer shows the minify diff