### PR TITLE
feat(cloudflare): point auth.tnwks.us at Cognito custom-domain CloudFront

### DIFF
--- a/infrastructure/terraform/cloudflare/main.tf
+++ b/infrastructure/terraform/cloudflare/main.tf
@@ -123,6 +123,18 @@ module "cf_domain_1" {
       type    = "CNAME"
       proxied = false
     },
+    # auth.tnwks.us → Cognito custom-domain CloudFront distribution. Value
+    # comes from the prod AWS workspace output
+    # cognito_custom_domain_cloudfront_distribution. Must not be proxied:
+    # Cloudflare's proxy would terminate TLS with the wrong cert (Cloudflare's,
+    # not the auth.tnwks.us ACM cert ATTACHED to the CloudFront distro).
+    {
+      id      = "cognito_custom_domain"
+      name    = "auth.tnwks.us"
+      value   = "d2sskyx0g75op2.cloudfront.net"
+      type    = "CNAME"
+      proxied = false
+    },
   ]
 
   waf_custom_rules = [


### PR DESCRIPTION
## Summary
- Adds CNAME `auth.tnwks.us` → `d2sskyx0g75op2.cloudfront.net` (the CloudFront distribution Cognito assigned to the user pool's custom domain).
- Not proxied — Cloudflare's proxy would terminate TLS with the wrong cert (Cloudflare's, not the auth.tnwks.us ACM cert attached to the CloudFront distro).
- Final step in the multi-PR Cognito custom-domain rollout (#1267 → #1268 → #1270 → this).

## Note
The Cloudflare workspace is `execution-mode: local` and not VCS-triggered, so this PR will need a local `terraform apply` from `infrastructure/terraform/cloudflare` after merge.

## Test plan
- [ ] `terraform apply` adds the CNAME
- [ ] `dig auth.tnwks.us` resolves to the CloudFront distribution
- [ ] `https://auth.tnwks.us/passkeys/add?client_id=...&redirect_uri=https://grafana.internal.tnwks.us/` loads the Managed Login passkey enrollment page
- [ ] Add Passkey button no longer errors with RPID mismatch