### PR TITLE
feat(cognito): customize invite email with passkey enrollment step

### DIFF
--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -44,6 +44,36 @@ resource "aws_cognito_user_pool" "tnwks_auth" {
 
   admin_create_user_config {
     allow_admin_create_user_only = true
+
+    # AWS requires {username} and {####} placeholders in email_message AND
+    # sms_message; without both the apply is rejected. {####} is replaced
+    # with the temp password, {username} with the Cognito username (== email).
+    # We never deliver via SMS (desired_delivery_mediums = ["EMAIL"]) but the
+    # API requires sms_message anyway.
+    #
+    # The passkey link deliberately doesn't pass client_id/redirect_uri:
+    # embedding aws_cognito_user_pool_client.oauth2_proxy.id here would create
+    # a pool↔client dependency cycle. The bare /passkeys/add URL works fine —
+    # Cognito just doesn't auto-redirect after enrollment.
+    invite_message_template {
+      email_subject = "Welcome to tnwks — finish setting up your account"
+      sms_message   = "Your tnwks username is {username} and temporary password is {####}"
+      email_message = <<-EOT
+        <p>Hi,</p>
+        <p>You've been invited to tnwks internal services. Onboarding is two steps:</p>
+        <p><strong>Step 1 — Sign in.</strong><br/>
+        Visit <a href="https://grafana.internal.tnwks.us/">https://grafana.internal.tnwks.us/</a> and sign in with:</p>
+        <ul>
+          <li>Username: <code>{username}</code></li>
+          <li>Temporary password: <code>{####}</code></li>
+        </ul>
+        <p>You'll be prompted to set a permanent password on first sign-in.</p>
+        <p><strong>Step 2 — Add a passkey (recommended).</strong><br/>
+        After you finish step 1, in the <em>same browser session</em>, open this link to register a passkey (Touch ID, Windows Hello, or a hardware key):</p>
+        <p><a href="https://auth.tnwks.us/passkeys/add">Register a passkey</a></p>
+        <p>Once registered, future sign-ins use your fingerprint, face, or key — you won't need to type the password again.</p>
+      EOT
+    }
   }
 
   schema {


### PR DESCRIPTION
## Summary
- Replaces Cognito's default invite email with a two-step onboarding template:
  1. Sign in at `https://grafana.internal.tnwks.us/` with the temp password Cognito injects
  2. Register a passkey at `https://auth.tnwks.us/passkeys/add` in the same browser session
- Surfaces the passkey option at the moment new users are most engaged with the auth flow.

## Why no client_id in the passkey link
Embedding `aws_cognito_user_pool_client.oauth2_proxy.id` in the email body would create a pool↔client dependency cycle (pool defines the template, template references the client, client points back at the pool). The bare `/passkeys/add` URL works fine — Cognito just doesn't auto-redirect after enrollment.

## Note
`sms_message` is required by the API even though we only deliver via email.

## Test plan
- [ ] terraform apply succeeds; pool's `admin_create_user_config.invite_message_template` is populated
- [ ] Re-creating the admin user (e.g. by changing `random_password.admin_temp.keepers`) sends the new email
- [ ] Email renders with two steps, both links clickable, `{username}` and `{####}` substituted correctly