### PR TITLE
chore(cognito): bump invite keeper to resend admin invitation

### DIFF
--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -220,6 +220,9 @@ resource "random_password" "admin_temp" {
   keepers = {
     username     = data.sops_file.secrets.data["admin_email"]
     auth_posture = "passkey-as-mfa-with-totp"
+    # Bump invite_template when the email body changes to force a fresh
+    # invitation send to the existing admin so they see the new template.
+    invite_template = "v1-passkey-step"
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `invite_template = "v1-passkey-step"` to `random_password.admin_temp.keepers` so the keeper hash changes, forcing replacement of `aws_cognito_user.admin` on next apply.
- Triggers Cognito to send a fresh invitation email to the admin address — rendered with the new two-step template from #1272 — so we can preview the onboarding flow.

## Test plan
- [x] terraform validate
- [ ] terraform apply replaces `random_password.admin_temp` and `aws_cognito_user.admin`
- [ ] Admin inbox receives the new invitation; email shows Step 1 (Grafana sign-in) and Step 2 (passkey enrollment) sections