### PR TITLE
feat(onboard): self-hosted static onboarding site at onboard.tnwks.us

### DIFF
--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -60,18 +60,12 @@ resource "aws_cognito_user_pool" "tnwks_auth" {
       sms_message   = "Your tnwks username is {username} and temporary password is {####}"
       email_message = <<-EOT
         <p>Hi,</p>
-        <p>You've been invited to tnwks internal services. Onboarding is two steps:</p>
-        <p><strong>Step 1 — Sign in.</strong><br/>
-        Visit <a href="https://grafana.internal.tnwks.us/">https://grafana.internal.tnwks.us/</a> and sign in with:</p>
+        <p>You've been invited to tnwks. To finish setting up your account, visit <a href="https://onboard.tnwks.us/">https://onboard.tnwks.us/</a> and sign in with:</p>
         <ul>
           <li>Username: <code>{username}</code></li>
           <li>Temporary password: <code>{####}</code></li>
         </ul>
-        <p>You'll be prompted to set a permanent password on first sign-in.</p>
-        <p><strong>Step 2 — Add a passkey (recommended).</strong><br/>
-        After you finish step 1, in the <em>same browser session</em>, open this link to register a passkey (Touch ID, Windows Hello, or a hardware key):</p>
-        <p><a href="https://auth.tnwks.us/passkeys/add">Register a passkey</a></p>
-        <p>Once registered, future sign-ins use your fingerprint, face, or key — you won't need to type the password again.</p>
+        <p>You'll be prompted to set a permanent password and then guided through registering a passkey (Touch ID, Windows Hello, or a hardware key) so future sign-ins are one touch.</p>
       EOT
     }
   }
@@ -222,7 +216,7 @@ resource "random_password" "admin_temp" {
     auth_posture = "passkey-as-mfa-with-totp"
     # Bump invite_template when the email body changes to force a fresh
     # invitation send to the existing admin so they see the new template.
-    invite_template = "v1-passkey-step"
+    invite_template = "v2-onboard-tnwks-us"
   }
 }
 
@@ -412,6 +406,47 @@ resource "terraform_data" "oauth2_proxy_managed_login" {
 }
 
 ## ---------------------------------------------------------------------------------------------------------------------
+## APP CLIENT - onboard
+## Public PKCE client for the static onboarding site at onboard.tnwks.us.
+## No client secret (browser app); ALLOW_USER_AUTH so passkey/choice-based
+## sign-in works the same as the oauth2-proxy client.
+## ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_cognito_user_pool_client" "onboard" {
+  name         = "onboard"
+  user_pool_id = aws_cognito_user_pool.tnwks_auth.id
+
+  generate_secret = false
+
+  callback_urls = ["https://onboard.tnwks.us/callback"]
+  logout_urls   = ["https://onboard.tnwks.us/"]
+
+  allowed_oauth_flows                  = ["code"]
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_scopes                 = ["openid", "email", "profile"]
+
+  supported_identity_providers = ["COGNITO"]
+
+  explicit_auth_flows = [
+    "ALLOW_USER_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+  ]
+
+  access_token_validity  = 1
+  id_token_validity      = 1
+  refresh_token_validity = 30
+
+  token_validity_units {
+    access_token  = "hours"
+    id_token      = "hours"
+    refresh_token = "days"
+  }
+
+  prevent_user_existence_errors = "ENABLED"
+  enable_token_revocation       = true
+}
+
+## ---------------------------------------------------------------------------------------------------------------------
 ## APP CLIENT - agent-ori
 ## ---------------------------------------------------------------------------------------------------------------------
 
@@ -547,6 +582,11 @@ output "cognito_oauth2_proxy_client_secret" {
   description = "App client secret for oauth2-proxy."
   value       = aws_cognito_user_pool_client.oauth2_proxy.client_secret
   sensitive   = true
+}
+
+output "cognito_onboard_client_id" {
+  description = "App client ID for the static onboarding site (onboard.tnwks.us). Public value — copied into kubernetes/apps/auth/onboard/app/static/config.js."
+  value       = aws_cognito_user_pool_client.onboard.id
 }
 
 output "cognito_agent_client_id" {

--- a/kubernetes/apps/auth/kustomization.yaml
+++ b/kubernetes/apps/auth/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./oauth2-proxy/ks.yaml
+  - ./onboard/ks.yaml

--- a/kubernetes/apps/auth/onboard/app/certificate.yaml
+++ b/kubernetes/apps/auth/onboard/app/certificate.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: onboard-tnwks-us
+  namespace: auth
+spec:
+  secretName: onboard-tnwks-us-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: onboard.tnwks.us
+  dnsNames:
+    - onboard.tnwks.us

--- a/kubernetes/apps/auth/onboard/app/deployment.yaml
+++ b/kubernetes/apps/auth/onboard/app/deployment.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: onboard
+  namespace: auth
+  labels:
+    app.kubernetes.io/name: onboard
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: onboard
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: onboard
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+      # WSL Talos doesn't chown emptyDir on fsGroup, so the writable scratch
+      # dirs nginx-unprivileged needs (/tmp, /var/cache/nginx, /var/run) come
+      # up root-owned and read-only-root-fs nginx can't open its pid file.
+      # Init container chowns them to uid 101 before the main container starts.
+      initContainers:
+        - name: chown-scratch
+          image: nginxinc/nginx-unprivileged:1.27-alpine
+          command:
+            - /bin/sh
+            - -c
+            - chown -R 101:101 /tmp /var/cache/nginx /var/run
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: var-cache-nginx
+              mountPath: /var/cache/nginx
+            - name: var-run
+              mountPath: /var/run
+      containers:
+        - name: nginx
+          image: nginxinc/nginx-unprivileged:1.27-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: static
+              mountPath: /usr/share/nginx/html
+              readOnly: true
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+            # Writable scratch dirs nginx-unprivileged needs even when serving
+            # static content read-only (temp paths, PID, cache).
+            - name: tmp
+              mountPath: /tmp
+            - name: var-cache-nginx
+              mountPath: /var/cache/nginx
+            - name: var-run
+              mountPath: /var/run
+      volumes:
+        - name: static
+          configMap:
+            name: onboard-static
+        - name: nginx-conf
+          configMap:
+            name: onboard-nginx
+        - name: tmp
+          emptyDir: {}
+        - name: var-cache-nginx
+          emptyDir: {}
+        - name: var-run
+          emptyDir: {}

--- a/kubernetes/apps/auth/onboard/app/ingress.yaml
+++ b/kubernetes/apps/auth/onboard/app/ingress.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: onboard
+  namespace: auth
+  annotations:
+    # Public site — onboard.tnwks.us is intentionally reachable without
+    # authentication so invitees can land here. Cognito enforces who can
+    # actually sign in. No oauth2-proxy auth-subrequest annotations.
+    external-dns.alpha.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - onboard.tnwks.us
+      secretName: onboard-tnwks-us-tls
+  rules:
+    - host: onboard.tnwks.us
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: onboard
+                port:
+                  name: http

--- a/kubernetes/apps/auth/onboard/app/kustomization.yaml
+++ b/kubernetes/apps/auth/onboard/app/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: auth
+resources:
+  - ./certificate.yaml
+  - ./deployment.yaml
+  - ./service.yaml
+  - ./ingress.yaml
+configMapGenerator:
+  - name: onboard-static
+    files:
+      - index.html=./static/index.html
+      - callback.html=./static/callback.html
+      - done.html=./static/done.html
+      - app.js=./static/app.js
+      - styles.css=./static/styles.css
+      - config.js=./static/config.js
+  - name: onboard-nginx
+    files:
+      - default.conf=./nginx/default.conf
+generatorOptions:
+  disableNameSuffixHash: false

--- a/kubernetes/apps/auth/onboard/app/nginx/default.conf
+++ b/kubernetes/apps/auth/onboard/app/nginx/default.conf
@@ -1,0 +1,33 @@
+server {
+    listen 8080 default_server;
+    listen [::]:8080 default_server;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Strict transport security: ingress-nginx already terminates TLS and sets
+    # HSTS, but adding it at the origin too is harmless and protects against
+    # misrouted plaintext traffic to the pod IP.
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # CSP: only this origin + auth.tnwks.us for the token-exchange POST.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://auth.tnwks.us; form-action 'self' https://auth.tnwks.us; frame-ancestors 'none'; base-uri 'self'" always;
+
+    location = /callback { try_files /callback.html =404; }
+    location = /done     { try_files /done.html =404; }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache the static assets aggressively — content is only changed via a
+    # ConfigMap rollout, which rolls the pod, so the asset URL is the same
+    # but the file is replaced. Use the kustomize hashed ConfigMap name to
+    # bust caches if this ever becomes an issue (currently not a concern).
+    location ~* \.(js|css)$ {
+        expires 5m;
+        add_header Cache-Control "public, max-age=300";
+    }
+}

--- a/kubernetes/apps/auth/onboard/app/service.yaml
+++ b/kubernetes/apps/auth/onboard/app/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: onboard
+  namespace: auth
+  labels:
+    app.kubernetes.io/name: onboard
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: onboard
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP

--- a/kubernetes/apps/auth/onboard/app/static/app.js
+++ b/kubernetes/apps/auth/onboard/app/static/app.js
@@ -1,0 +1,144 @@
+// Browser-only PKCE helpers + session check shared by index.html and
+// callback.html. Modern browsers only — uses crypto.subtle and fetch.
+
+const SESSION_KEYS = {
+  verifier: "onboard.pkce_verifier",
+  state: "onboard.pkce_state",
+  idToken: "onboard.id_token",
+  accessToken: "onboard.access_token",
+  refreshToken: "onboard.refresh_token",
+  tokenExpiresAt: "onboard.token_expires_at",
+};
+
+function cfg() {
+  if (!window.ONBOARD_CONFIG) {
+    throw new Error("ONBOARD_CONFIG missing — config.js failed to load");
+  }
+  return window.ONBOARD_CONFIG;
+}
+
+function base64UrlEncode(bytes) {
+  let bin = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    bin += String.fromCharCode(bytes[i]);
+  }
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function randomBytes(n) {
+  const a = new Uint8Array(n);
+  crypto.getRandomValues(a);
+  return a;
+}
+
+async function sha256(input) {
+  const enc = new TextEncoder().encode(input);
+  const hash = await crypto.subtle.digest("SHA-256", enc);
+  return new Uint8Array(hash);
+}
+
+async function generatePkce() {
+  const verifier = base64UrlEncode(randomBytes(32));
+  const challenge = base64UrlEncode(await sha256(verifier));
+  const state = base64UrlEncode(randomBytes(16));
+  return { verifier, challenge, state };
+}
+
+function hasValidSession() {
+  const token = sessionStorage.getItem(SESSION_KEYS.accessToken);
+  if (!token) return false;
+  const expRaw = sessionStorage.getItem(SESSION_KEYS.tokenExpiresAt);
+  if (!expRaw) return false;
+  const exp = parseInt(expRaw, 10);
+  if (Number.isNaN(exp)) return false;
+  return Date.now() < exp - 30_000;
+}
+
+async function startAuthRedirect() {
+  const { verifier, challenge, state } = await generatePkce();
+  sessionStorage.setItem(SESSION_KEYS.verifier, verifier);
+  sessionStorage.setItem(SESSION_KEYS.state, state);
+  const c = cfg();
+  const url = new URL(`https://${c.cognitoDomain}/oauth2/authorize`);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", c.clientId);
+  url.searchParams.set("redirect_uri", c.redirectUri);
+  url.searchParams.set("scope", "openid email profile");
+  url.searchParams.set("code_challenge", challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("state", state);
+  window.location.assign(url.toString());
+}
+
+async function exchangeCodeForTokens(code) {
+  const c = cfg();
+  const verifier = sessionStorage.getItem(SESSION_KEYS.verifier);
+  if (!verifier) {
+    throw new Error(
+      "Missing PKCE verifier in this browser. Please start over from the home page.",
+    );
+  }
+  const body = new URLSearchParams();
+  body.set("grant_type", "authorization_code");
+  body.set("client_id", c.clientId);
+  body.set("code", code);
+  body.set("redirect_uri", c.redirectUri);
+  body.set("code_verifier", verifier);
+
+  const res = await fetch(`https://${c.cognitoDomain}/oauth2/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    let detail = "";
+    try {
+      const j = await res.json();
+      detail = j.error_description || j.error || JSON.stringify(j);
+    } catch (_) {
+      detail = await res.text();
+    }
+    throw new Error(`Token exchange failed (${res.status}): ${detail}`);
+  }
+  const tok = await res.json();
+  if (tok.access_token)
+    sessionStorage.setItem(SESSION_KEYS.accessToken, tok.access_token);
+  if (tok.id_token) sessionStorage.setItem(SESSION_KEYS.idToken, tok.id_token);
+  if (tok.refresh_token)
+    sessionStorage.setItem(SESSION_KEYS.refreshToken, tok.refresh_token);
+  if (tok.expires_in) {
+    const exp = Date.now() + parseInt(tok.expires_in, 10) * 1000;
+    sessionStorage.setItem(SESSION_KEYS.tokenExpiresAt, String(exp));
+  }
+  sessionStorage.removeItem(SESSION_KEYS.verifier);
+  sessionStorage.removeItem(SESSION_KEYS.state);
+}
+
+function passkeyAddUrl() {
+  const c = cfg();
+  const url = new URL(`https://${c.cognitoDomain}/passkeys/add`);
+  url.searchParams.set("client_id", c.clientId);
+  url.searchParams.set("redirect_uri", "https://onboard.tnwks.us/done");
+  return url.toString();
+}
+
+function logoutUrl() {
+  const c = cfg();
+  const url = new URL(`https://${c.cognitoDomain}/logout`);
+  url.searchParams.set("client_id", c.clientId);
+  url.searchParams.set("logout_uri", "https://onboard.tnwks.us/");
+  return url.toString();
+}
+
+function clearSession() {
+  Object.values(SESSION_KEYS).forEach((k) => sessionStorage.removeItem(k));
+}
+
+window.Onboard = {
+  hasValidSession,
+  startAuthRedirect,
+  exchangeCodeForTokens,
+  passkeyAddUrl,
+  logoutUrl,
+  clearSession,
+};

--- a/kubernetes/apps/auth/onboard/app/static/callback.html
+++ b/kubernetes/apps/auth/onboard/app/static/callback.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+    <meta name="robots" content="noindex,nofollow" />
+    <title>Signing you in… — tnwks</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main>
+      <div class="brand">
+        <span class="brand-dot"></span>
+        <span>tnwks onboarding</span>
+      </div>
+      <div class="card" id="card">
+        <h1>Finishing sign-in…</h1>
+        <p class="subtitle"><span class="spinner"></span>One moment.</p>
+      </div>
+    </main>
+    <script src="/config.js"></script>
+    <script src="/app.js"></script>
+    <script>
+      (async () => {
+        const card = document.getElementById("card");
+        const url = new URL(window.location.href);
+        const code = url.searchParams.get("code");
+        const error = url.searchParams.get("error");
+        const errorDescription = url.searchParams.get("error_description");
+        const state = url.searchParams.get("state");
+        const expectedState = sessionStorage.getItem("onboard.pkce_state");
+
+        function showError(message) {
+          card.innerHTML = `
+            <div class="error">${message}</div>
+            <a class="cta" href="/">Try again</a>
+          `;
+        }
+
+        if (error) {
+          showError(`${error}: ${errorDescription || "no details"}`);
+          return;
+        }
+        if (!code) {
+          showError("Missing authorization code in callback URL.");
+          return;
+        }
+        if (!expectedState || state !== expectedState) {
+          showError(
+            "State mismatch — the sign-in flow may have been started in a different tab. Please try again.",
+          );
+          return;
+        }
+
+        try {
+          await window.Onboard.exchangeCodeForTokens(code);
+          window.location.replace("/");
+        } catch (err) {
+          showError((err && err.message) || "Token exchange failed.");
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/kubernetes/apps/auth/onboard/app/static/config.js
+++ b/kubernetes/apps/auth/onboard/app/static/config.js
@@ -1,0 +1,10 @@
+// Public OAuth client config. Client ID is not a secret — it identifies the
+// browser-side PKCE client to Cognito and is safe to commit. Updated when
+// aws_cognito_user_pool_client.onboard is recreated (TFC apply emits the
+// cognito_onboard_client_id output).
+window.ONBOARD_CONFIG = {
+  cognitoDomain: "auth.tnwks.us",
+  clientId: "REPLACE_WITH_ONBOARD_CLIENT_ID",
+  redirectUri: "https://onboard.tnwks.us/callback",
+  rpId: "tnwks.us",
+};

--- a/kubernetes/apps/auth/onboard/app/static/done.html
+++ b/kubernetes/apps/auth/onboard/app/static/done.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+    <meta name="robots" content="noindex,nofollow" />
+    <title>You're all set — tnwks</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main>
+      <div class="brand">
+        <span class="brand-dot"></span>
+        <span>tnwks onboarding</span>
+      </div>
+      <div class="card">
+        <h1>You're all set.</h1>
+        <p class="subtitle">
+          Your passkey is registered. From now on, signing in is one touch.
+        </p>
+        <ul class="steps">
+          <li class="step done">
+            <div class="step-marker">✓</div>
+            <div class="step-body">
+              <div class="step-title">Account ready</div>
+              <p class="step-meta">Signed in with your tnwks credentials.</p>
+            </div>
+          </li>
+          <li class="step done">
+            <div class="step-marker">✓</div>
+            <div class="step-body">
+              <div class="step-title">Passkey registered</div>
+              <p class="step-meta">
+                Future sign-ins will use your fingerprint, face, or key.
+              </p>
+            </div>
+          </li>
+        </ul>
+        <a class="cta" id="logout-cta" href="#">Sign out and finish</a>
+      </div>
+      <footer>
+        You can close this tab — the rest is up to you.
+      </footer>
+    </main>
+    <script src="/config.js"></script>
+    <script src="/app.js"></script>
+    <script>
+      const a = document.getElementById("logout-cta");
+      a.href = window.Onboard.logoutUrl();
+      a.addEventListener("click", () => window.Onboard.clearSession());
+    </script>
+  </body>
+</html>

--- a/kubernetes/apps/auth/onboard/app/static/index.html
+++ b/kubernetes/apps/auth/onboard/app/static/index.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+    <meta name="robots" content="noindex,nofollow" />
+    <title>Welcome — tnwks</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main>
+      <div class="brand">
+        <span class="brand-dot"></span>
+        <span>tnwks onboarding</span>
+      </div>
+      <div class="card" id="card">
+        <h1 id="title">Setting up your account…</h1>
+        <p class="subtitle" id="subtitle">
+          <span class="spinner"></span>One moment.
+        </p>
+      </div>
+      <footer>
+        Need help? Reply to your invitation email and we'll sort it out.
+      </footer>
+    </main>
+    <script src="/config.js"></script>
+    <script src="/app.js"></script>
+    <script>
+      (async () => {
+        const card = document.getElementById("card");
+        try {
+          if (!window.Onboard.hasValidSession()) {
+            await window.Onboard.startAuthRedirect();
+            return;
+          }
+          card.innerHTML = `
+            <h1>You're signed in. One step left.</h1>
+            <p class="subtitle">Add a passkey so you don't have to type your password every time.</p>
+            <ul class="steps">
+              <li class="step done">
+                <div class="step-marker">✓</div>
+                <div class="step-body">
+                  <div class="step-title">Account ready</div>
+                  <p class="step-meta">Signed in with your tnwks credentials.</p>
+                </div>
+              </li>
+              <li class="step active">
+                <div class="step-marker">2</div>
+                <div class="step-body">
+                  <div class="step-title">Add a passkey</div>
+                  <p class="step-meta">Touch ID, Windows Hello, or a hardware key — whatever your device offers.</p>
+                </div>
+              </li>
+            </ul>
+            <a class="cta" id="passkey-cta">Add a passkey</a>
+            <a class="cta-secondary" id="logout-link">Sign out</a>
+          `;
+          document.getElementById("passkey-cta").href =
+            window.Onboard.passkeyAddUrl();
+          const logoutLink = document.getElementById("logout-link");
+          logoutLink.href = window.Onboard.logoutUrl();
+          logoutLink.addEventListener("click", () =>
+            window.Onboard.clearSession(),
+          );
+        } catch (err) {
+          card.innerHTML = `
+            <div class="error">${(err && err.message) || "Something went wrong."}</div>
+            <a class="cta" href="/">Try again</a>
+          `;
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/kubernetes/apps/auth/onboard/app/static/styles.css
+++ b/kubernetes/apps/auth/onboard/app/static/styles.css
@@ -1,0 +1,238 @@
+:root {
+  --bg: #0b0d10;
+  --panel: #14181d;
+  --panel-2: #1b2128;
+  --text: #e7ecf3;
+  --muted: #8a95a5;
+  --accent: #5b8def;
+  --accent-hover: #7aa1ff;
+  --accent-text: #0b0d10;
+  --ok: #3ecf8e;
+  --border: #232a33;
+  --shadow: 0 8px 32px rgba(0, 0, 0, 0.32);
+  --radius: 14px;
+  --radius-sm: 8px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+    Cantarell, "Helvetica Neue", sans-serif;
+  font-size: 16px;
+  line-height: 1.55;
+  min-height: 100%;
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 24px;
+}
+
+main {
+  width: 100%;
+  max-width: 520px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 28px;
+  color: var(--muted);
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.brand-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(91, 141, 239, 0.18);
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 32px;
+  box-shadow: var(--shadow);
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin: 0 0 8px 0;
+  line-height: 1.25;
+}
+
+.subtitle {
+  color: var(--muted);
+  margin: 0 0 24px 0;
+}
+
+.steps {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 28px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.step {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 14px 16px;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.step-marker {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.9rem;
+  background: var(--panel);
+  color: var(--muted);
+  border: 1px solid var(--border);
+}
+
+.step.done .step-marker {
+  background: var(--ok);
+  color: var(--accent-text);
+  border-color: var(--ok);
+}
+
+.step.active .step-marker {
+  background: var(--accent);
+  color: var(--accent-text);
+  border-color: var(--accent);
+}
+
+.step-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.step-title {
+  font-weight: 600;
+  margin: 2px 0 2px 0;
+}
+
+.step-meta {
+  color: var(--muted);
+  font-size: 0.92rem;
+  margin: 0;
+}
+
+.cta {
+  display: block;
+  width: 100%;
+  text-align: center;
+  padding: 16px 20px;
+  background: var(--accent);
+  color: var(--accent-text);
+  font-weight: 600;
+  font-size: 1.05rem;
+  border: none;
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    transform 60ms ease;
+}
+
+.cta:hover {
+  background: var(--accent-hover);
+}
+
+.cta:active {
+  transform: translateY(1px);
+}
+
+.cta-secondary {
+  display: inline-block;
+  margin-top: 14px;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.92rem;
+}
+
+.cta-secondary:hover {
+  color: var(--text);
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.error {
+  background: rgba(239, 91, 91, 0.08);
+  border: 1px solid rgba(239, 91, 91, 0.32);
+  color: #ffd6d6;
+  padding: 14px 16px;
+  border-radius: var(--radius-sm);
+  margin-bottom: 20px;
+}
+
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 700ms linear infinite;
+  vertical-align: -2px;
+  margin-right: 8px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+footer {
+  margin-top: 24px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+footer a {
+  color: var(--muted);
+}
+
+@media (max-width: 480px) {
+  .card {
+    padding: 24px 20px;
+  }
+  h1 {
+    font-size: 1.3rem;
+  }
+}

--- a/kubernetes/apps/auth/onboard/ks.yaml
+++ b/kubernetes/apps/auth/onboard/ks.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: onboard
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: ingress-nginx
+  path: ./kubernetes/apps/auth/onboard/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Summary

- New Flux app at `kubernetes/apps/auth/onboard/`: nginx-unprivileged Deployment serving static HTML/CSS/JS from a ConfigMap, public Ingress on class `nginx`, cert-manager Certificate against `letsencrypt-production`. external-dns publishes the CNAME automatically (existing `tnwks.us` domainFilter).
- Static onboarding site that runs PKCE in the browser against `auth.tnwks.us`, then steers new users to `/passkeys/add` as the primary action. Password+TOTP remains as the fallback path.
- New `aws_cognito_user_pool_client.onboard` (public PKCE client, no secret); invite email rewritten to send invitees to `onboard.tnwks.us`; `random_password.admin_temp` keeper bumped so pending invitees receive the refreshed email.

## Scope notes

- No GitHub Actions workflow added — Flux reconciles, ConfigMaps are inlined, no container build.
- `config.js` ships with a placeholder `clientId`. After this PR merges and TFC applies the new Cognito client, a follow-up commit fills in the real `cognito_onboard_client_id` output value.
- DNS, cloudflared tunnel ingress, and the `letsencrypt-production` Cloudflare DNS01 solver were verified on the live cluster to already cover `tnwks.us` (external-dns `--domain-filter=tnwks.us`, cloudflared routes `*.${SECRET_DOMAIN}` where `SECRET_DOMAIN=tnwks.us` per cluster-secrets, issuer selector matches `${SECRET_DOMAIN}`). No changes needed there.

## Test plan

- [ ] PR merges → Flux reconciles `kubernetes/apps/auth/onboard` on the wsl cluster
- [ ] `kubectl -n auth get certificate onboard-tnwks-us` becomes Ready
- [ ] external-dns publishes `onboard.tnwks.us` CNAME → `ingress.tnwks.us`
- [ ] TFC apply on push to main creates `aws_cognito_user_pool_client.onboard`; output `cognito_onboard_client_id` is populated
- [ ] Follow-up commit substitutes the real client ID into `config.js`
- [ ] Visit `https://onboard.tnwks.us/` in a browser, complete PKCE → land on Step-2-add-a-passkey card → `/passkeys/add` succeeds → land on `/done`