### PR TITLE
feat(sites): add Sites Platform — NFS share, nginx, GHA runner

### DIFF
--- a/kubernetes/apps/production/sites/app/configmap.yaml
+++ b/kubernetes/apps/production/sites/app/configmap.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sites-nginx
+  namespace: production
+data:
+  # Drop-in server block — mounted at /etc/nginx/conf.d/default.conf, which the
+  # stock nginx image includes from its packaged nginx.conf.
+  default.conf: |
+    server {
+        listen 80;
+        root /usr/share/nginx/html;
+        index index.html;
+
+        # Root SPA fallback (a site published directly at /).
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+
+        # Per-project SPA fallback: requests under /<project>/ that don't map
+        # to a real file fall back to that project's index.html so Angular
+        # client-side routing works at sites.tnwks.us/<project>/.
+        location ~ ^/([^/]+)/ {
+            try_files $uri $uri/ /$1/index.html =404;
+        }
+    }

--- a/kubernetes/apps/production/sites/app/deployment.yaml
+++ b/kubernetes/apps/production/sites/app/deployment.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sites
+  namespace: production
+  labels:
+    app.kubernetes.io/name: sites
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sites
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sites
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/library/nginx:1.27-alpine
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          volumeMounts:
+            # Static site content, served read-only from the shared NFS export.
+            - name: sites
+              mountPath: /usr/share/nginx/html
+              readOnly: true
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: sites
+          nfs:
+            # nfs-server Service in the storage namespace exports / (fsid=0).
+            server: nfs-server.storage.svc.cluster.local
+            path: /
+            readOnly: true
+        - name: nginx-config
+          configMap:
+            name: sites-nginx

--- a/kubernetes/apps/production/sites/app/ingress.yaml
+++ b/kubernetes/apps/production/sites/app/ingress.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sites
+  namespace: production
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
+spec:
+  ingressClassName: nginx
+  # No secretName — the ingress-nginx default-ssl-certificate is the
+  # wildcard *.${SECRET_DOMAIN} cert, which covers sites.${SECRET_DOMAIN}.
+  tls:
+    - hosts:
+        - "sites.${SECRET_DOMAIN}"
+  rules:
+    - host: "sites.${SECRET_DOMAIN}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sites
+                port:
+                  name: http

--- a/kubernetes/apps/production/sites/app/kustomization.yaml
+++ b/kubernetes/apps/production/sites/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: production
+resources:
+  - ./configmap.yaml
+  - ./deployment.yaml
+  - ./service.yaml
+  - ./ingress.yaml

--- a/kubernetes/apps/production/sites/app/service.yaml
+++ b/kubernetes/apps/production/sites/app/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sites
+  namespace: production
+  labels:
+    app.kubernetes.io/name: sites
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: sites
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP

--- a/kubernetes/apps/production/sites/ks.yaml
+++ b/kubernetes/apps/production/sites/ks.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: sites
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/production/sites/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false # no flux ks dependents
+  # nginx mounts the NFS export served by the nfs-server Kustomization
+  # (storage namespace); gate on it so the share exists before pods start.
+  dependsOn:
+    - name: nfs-server
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/storage/namespace.yaml
+++ b/kubernetes/apps/storage/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: storage
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    # nfs-server runs privileged (CAP_SYS_ADMIN + access to the host nfsd
+    # kernel module) to export the /sites share, which PSA baseline forbids.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/kubernetes/apps/storage/nfs-server/app/deployment.yaml
+++ b/kubernetes/apps/storage/nfs-server/app/deployment.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nfs-server
+  namespace: storage
+  labels:
+    app.kubernetes.io/name: nfs-server
+spec:
+  # NFS state (the exported /sites tree) lives on a single RWO PVC, so this
+  # must stay single-replica — Recreate avoids two pods racing for the volume.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nfs-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nfs-server
+    spec:
+      containers:
+        - name: nfs-server
+          # erichough/nfs-server — ganesha/kernel NFS server. Exports each
+          # directory listed in NFS_EXPORT_* env vars; rw + no_root_squash so
+          # the actions-runner can write build output as any uid.
+          image: docker.io/erichough/nfs-server:2.2.1
+          env:
+            - name: NFS_EXPORT_0
+              value: "/sites *(rw,fsid=0,sync,no_subtree_check,no_root_squash,insecure)"
+            # nfsd thread count; the default of 8 is plenty for a single
+            # nginx reader plus the runner.
+            - name: NFS_SERVER_THREAD_COUNT
+              value: "8"
+          ports:
+            - name: nfs
+              containerPort: 2049
+              protocol: TCP
+            - name: mountd
+              containerPort: 20048
+              protocol: TCP
+            - name: rpcbind
+              containerPort: 111
+              protocol: TCP
+          securityContext:
+            # NFS kernel server needs SYS_ADMIN (mount namespaces, nfsd) and
+            # access to the host's nfs/nfsd kernel modules — privileged is the
+            # documented requirement for this image.
+            privileged: true
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - SYS_MODULE
+          volumeMounts:
+            - name: data
+              mountPath: /sites
+            # erichough/nfs-server loads nfs/nfsd modules from the host's
+            # kernel module tree at startup.
+            - name: kernel-modules
+              mountPath: /lib/modules
+              readOnly: true
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: nfs-server-data
+        - name: kernel-modules
+          hostPath:
+            path: /lib/modules

--- a/kubernetes/apps/storage/nfs-server/app/kustomization.yaml
+++ b/kubernetes/apps/storage/nfs-server/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: storage
+resources:
+  - ./pvc.yaml
+  - ./deployment.yaml
+  - ./service.yaml

--- a/kubernetes/apps/storage/nfs-server/app/pvc.yaml
+++ b/kubernetes/apps/storage/nfs-server/app/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-server-data
+  namespace: storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: "${STORAGE_CLASS_DEFAULT}"
+  resources:
+    requests:
+      storage: 10Gi

--- a/kubernetes/apps/storage/nfs-server/app/service.yaml
+++ b/kubernetes/apps/storage/nfs-server/app/service.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nfs-server
+  namespace: storage
+  labels:
+    app.kubernetes.io/name: nfs-server
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: nfs-server
+  ports:
+    - name: nfs
+      port: 2049
+      targetPort: nfs
+      protocol: TCP
+    - name: mountd
+      port: 20048
+      targetPort: mountd
+      protocol: TCP
+    - name: rpcbind
+      port: 111
+      targetPort: rpcbind
+      protocol: TCP

--- a/kubernetes/apps/storage/nfs-server/ks.yaml
+++ b/kubernetes/apps/storage/nfs-server/ks.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: nfs-server
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/storage/nfs-server/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  # nginx (production) and actions-runner (tools) mount this export, so other
+  # Flux Kustomizations depend on it — wait for the share to come up.
+  wait: true
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: nfs-server
+      namespace: storage
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/tools/actions-runner-controller/controller/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/actions-runner-controller/controller/app/helmrelease.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2beta2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: actions-runner-controller
+  namespace: tools
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: actions-runner-controller
+      version: 0.23.7
+      sourceRef:
+        kind: HelmRepository
+        name: actions-runner-controller
+        namespace: flux-system
+  maxHistory: 2
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    # GitHub auth — the controller reads the PAT from this pre-created secret
+    # (see secret.sops.yaml) rather than the chart generating its own.
+    authSecret:
+      enabled: true
+      create: false
+      name: controller-manager
+    metrics:
+      serviceMonitor:
+        enable: ${SERVICE_MONITOR_ENABLED}
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        memory: 256Mi

--- a/kubernetes/apps/tools/actions-runner-controller/controller/app/kustomization.yaml
+++ b/kubernetes/apps/tools/actions-runner-controller/controller/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tools
+resources:
+  - ./secret.sops.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/tools/actions-runner-controller/controller/app/secret.sops.yaml
+++ b/kubernetes/apps/tools/actions-runner-controller/controller/app/secret.sops.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: controller-manager
+    namespace: tools
+type: Opaque
+stringData:
+    #ENC[AES256_GCM,data:DGkd4+ZARDyq/ITJ8hU2f5s6H7VQ6wgPMdxxcl+MvWIw9+wZ3H8mle7bZ+POlj2vNWFGBxTub4ww8WWKRtM+EeKa3EutRCg2TXXe8Q==,iv:y+LshPHJgPCC/dp/WoZ7T0ekrTdIcescjpuuGgiA0OE=,tag:7Yc/SgUArY6hioa3AN/gIQ==,type:comment]
+    #ENC[AES256_GCM,data:CpeLbcRtCDdAoyf9ef+o0/4aG9L+dzvg5oNvXIT8oUOVgrMTUVVXwWSkawGy13zaDAKUfLHNiNG0l9iEsv2hOGrIguVKt8TtsIY=,iv:klOSdPhaStvRAwYcFOyups+bTZxvGjVShHnpPOfnxr8=,tag:1YtUB9gRKaCaSdTn9eyT5w==,type:comment]
+    #ENC[AES256_GCM,data:InMj//jTnU7OHuMcRRFZTnTPEWYPGTGWCfTRUltNKwRL+ApDOALp0C+49C0P1KWwFeEMPbB22ycTXw==,iv:eoSalC8otGPC7TrnOQ4CWJOYnmxL8NrvFcfa5cOHe1Y=,tag:nsEyCMV6d5D4+OpRKp/TXA==,type:comment]
+    github_token: ENC[AES256_GCM,data:5CRpJcjgsMrb32CHy98yCAVUCXb4,iv:2OjoYSldyIhT5LnRlDmcA1KXASq8Dz/kwJov9vHF43M=,tag:1ed5je0p0bc8LOYmlFUPgA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1mzxwncaj0364q8jxfj0y73ptt63czwxucf9lrnn28c7kwyr5wfdsj9gsk2
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTOC82WWNPeG16bnBHZlNk
+            R1N5UXhFVUk0amMxWXNBVjR0RkhZbnErY200CmxqNVZlRW1Zem40dmtiN3ZlbW9t
+            cFRlU1o3bXR2UlpKZ21tY1RsMWJvZW8KLS0tIDlsQnd4cHVaUHhqRlJPZW5RdkZr
+            Wmhjc3E4eUdiRkRjdHFXMFZWOEFQaDQKRYfygRDfCftlRuLSkCn9plxv3WabUlBb
+            TbHVsJhTLEb7VT43Notnc9srHw9pyewdFdWh1EiWwZJjTDoMJ6dhKA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age12uckcdwv9p2s75ae3h20wgn70taatdzzl44n9x6vr8h9qurzkaqqkhphz7
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXcDk3eEpCMEpEeVQ1NlU3
+            eFVoSEhsS1VpOGJPMjhGNTJ0V2dzankrS3dFCmdiZ3N3SWVYTkVqVExKSnBXNXdS
+            dTBCbnBrZFBpZURtOGJzMXdvK01Eb0EKLS0tIHhqckQySG5CWGFFY05sa0NqVnkr
+            T3UzdFRwVlpEc1MxU2w0TzNzTjlsajAKeH3R0rGUUQoO8c63zzkR+vsPV2HvpPGN
+            TnLE5g4oeNWOvinG3BqD6PPHgLJP/Q2cAraI0Yh4fXoyCi5UCEsp/w==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hmmuna95ktwl9sf9j56wjjukyf22ukdyjd8c47nlf5fjgyeyk5rsmhtyjx
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkbnlRUW1iS1d2V29pb0hT
+            b3FBREpiNDd1c0xEWkRTRXd4U01SNnppV0RRCjZLWXZRTWt1T1g0T3E0RE9IbytB
+            MlJFajZUNG9kdUJrYjlhcFFlNitOQ2sKLS0tIFlOZ245d2ZVV1dabGFWczVBMGZp
+            UDRSbW5tR2dDYWJYODM5am5HRXFTa3MKoDifSCTRGyM40UJMEOSj9QMBicJ+b1hL
+            CDEbMIHnPB37mNrvULLGQ5juaD2mnuxRyQxU1Be14G3FXX87XwfTZg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-01T04:00:00Z"
+    mac: ENC[AES256_GCM,data:Z//db4ybgCWtHfhnZVfftQ4ashahdTGTLDanw+TluMgy8Un9LoMFDwRzpz53X7cTky28bP3RQJFY1FAUnrdVMoy7cgJ62DtUL6bzyiadIE4+Yx9J3KMx2uSwxMRkRnztVHPu5flHqkn7uI6xRqAlzUHjGXcs2ML1G5vQwotSkME=,iv:2DHG+pX4NRxcdBUPPQ48LMmfoerBRTCdS8vwQvmkucE=,tag:GsUeTkoBraR1OhbyVXMbMg==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.3

--- a/kubernetes/apps/tools/actions-runner-controller/controller/ks.yaml
+++ b/kubernetes/apps/tools/actions-runner-controller/controller/ks.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: actions-runner-controller
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/tools/actions-runner-controller/controller/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  # The runner Kustomization depends on the controller's CRDs/webhook, so
+  # block until the HelmRelease is healthy.
+  wait: true
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: actions-runner-controller
+      namespace: tools
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/tools/actions-runner-controller/runner/app/kustomization.yaml
+++ b/kubernetes/apps/tools/actions-runner-controller/runner/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tools
+resources:
+  - ./runnerdeployment.yaml

--- a/kubernetes/apps/tools/actions-runner-controller/runner/app/runnerdeployment.yaml
+++ b/kubernetes/apps/tools/actions-runner-controller/runner/app/runnerdeployment.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: sites-builder
+  namespace: tools
+spec:
+  # Single static runner for now; scale via replicas or a HorizontalRunner
+  # Autoscaler later if build volume grows.
+  replicas: 1
+  template:
+    spec:
+      # Repo-scoped runner for the Angular source repo. GHA workflows target
+      # it with `runs-on: sites-builder` (the label below).
+      repository: iT3E/tnwks-sites
+      labels:
+        - sites-builder
+      # Mount the shared NFS export at /sites so build jobs can publish their
+      # dist/ output straight onto the volume nginx serves.
+      volumes:
+        - name: sites
+          nfs:
+            server: nfs-server.storage.svc.cluster.local
+            path: /
+      volumeMounts:
+        - name: sites
+          mountPath: /sites
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 2Gi

--- a/kubernetes/apps/tools/actions-runner-controller/runner/ks.yaml
+++ b/kubernetes/apps/tools/actions-runner-controller/runner/ks.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: sites-runner
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/tools/actions-runner-controller/runner/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  # Needs the ARC CRDs/webhook (controller) and the NFS export it mounts at
+  # /sites (nfs-server, storage namespace).
+  dependsOn:
+    - name: actions-runner-controller
+    - name: nfs-server
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/flux/meta/helm/actions-runner-controller.yaml
+++ b/kubernetes/flux/meta/helm/actions-runner-controller.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: actions-runner-controller
+  namespace: flux-system
+spec:
+  interval: 2h
+  url: https://actions-runner-controller.github.io/actions-runner-controller

--- a/kubernetes/flux/meta/helm/kustomization.yaml
+++ b/kubernetes/flux/meta/helm/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./actions-runner-controller.yaml
   - ./ananace.yaml
   - ./angelnu.yaml
   - ./bitnami.yaml


### PR DESCRIPTION
## What

Stands up the **Sites Platform** — serves AI-agent-built Angular frontends at `sites.${SECRET_DOMAIN}/<project>/`.

Three components, placed per repo conventions:

| Component | Path | Namespace |
|---|---|---|
| NFS server (nfs-ganesha) | `kubernetes/apps/storage/nfs-server/` | `storage` (new) |
| nginx (sites) | `kubernetes/apps/production/sites/` | `production` |
| GitHub Actions runner (ARC) | `kubernetes/apps/tools/actions-runner-controller/` | `tools` |

## Details

- **nfs-server** — `erichough/nfs-server` pod exporting `/sites` over a ClusterIP Service, backed by a 10Gi `${STORAGE_CLASS_DEFAULT}` PVC. Runs privileged (`storage` namespace is PSA-privileged).
- **sites (nginx)** — serves the NFS export read-only with per-project SPA `try_files` fallback so Angular client-side routing works at `/<project>/`. Ingress on `sites.${SECRET_DOMAIN}` using the wildcard `*.${SECRET_DOMAIN}` default-ssl-certificate.
- **actions-runner-controller** — legacy ARC HelmRelease (`controller/`) + repo-scoped `RunnerDeployment` (`runner/`) labeled `sites-builder`, repo `iT3E/tnwks-sites`, mounting the same NFS export at `/sites`. GitHub PAT placeholder lives in a sops-age-encrypted `controller-manager` secret — **replace before use**.

## Flux wiring

- `nginx` and `sites-runner` `dependsOn` → `nfs-server`; `sites-runner` also `dependsOn` → `actions-runner-controller`.
- Adds the `actions-runner-controller` HelmRepository to `flux/meta/helm/`.
- Group-level `kustomization.yaml` aggregators and cluster overlays are intentionally **left untouched** — the WSL overlay will be wired in separately.

## Validation

- `kustomize build` passes for all four app dirs + `flux/meta`.
- `kubectl apply --dry-run=client` passes for all rendered manifests (RunnerDeployment needs the ARC CRD, installed by the controller at runtime).
- sops secret decrypts with the age key family used by the cluster `sops-age` key.

> ⚠️ KMS was unreachable from the authoring environment, so the secret is encrypted with the repo's **age recipients only** (no AWS KMS key). The cluster decrypts via age, so this is functional — re-run `sops updatekeys` from a KMS-capable host if you want the KMS recipient restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
