### PR TITLE
fix(flux): point WSL GitRepository at main to match live cluster state

### DIFF
--- a/kubernetes/clusters/wsl/flux-system/gotk-sync.yaml
+++ b/kubernetes/clusters/wsl/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: restructure/multi-cluster
+    branch: main
   secretRef:
     name: flux-system
   url: ssh://git@github.com/iT3E/tnwks-ops


### PR DESCRIPTION
## What

Updates the committed `gotk-sync.yaml` so the WSL cluster's `flux-system` GitRepository tracks `main` instead of the long-merged `restructure/multi-cluster` branch.

## Why

The running cluster is **already** reconciling `main` — verified live:

```
$ flux get sources git -A
flux-system  flux-system  main@sha1:8eb02690  False  True  stored artifact for revision 'main@sha1:8eb02690'
```

But the committed (flux-generated, `# DO NOT EDIT`) manifest still said `branch: restructure/multi-cluster`. The live `GitRepository` was reconfigured out-of-band and the manifest was never regenerated, so git and the cluster had diverged. This makes the file match reality so a future re-bootstrap / `flux bootstrap` doesn't silently revert the cluster back to the stale branch.

No functional change to the running cluster — it's already on `main`.

## Validation

- `kustomize build kubernetes/clusters/wsl` ✅
- Live state confirms `main@8eb02690` is the reconciled revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
