### PR TITLE
feat(sites): enable dind on the runner + populate GitHub App secret

### DIFF
--- a/kubernetes/apps/tools/actions-runner-controller/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/actions-runner-controller/runner/app/helmrelease.yaml
@@ -45,16 +45,65 @@ spec:
     controllerServiceAccount:
       namespace: tools
       name: gha-runner-scale-set-controller-gha-rs-controller
-    # Default to dind-less "kubernetes-novolume" would require hooks; the
-    # Angular build just needs node + the NFS share, so use the plain runner
-    # pod template and mount the shared export at /sites.
+    # Docker-in-Docker. The chart's `containerMode: dind` shortcut can't be
+    # combined with a custom template, and we need a custom template for the
+    # NFS mount — so the full dind pod spec is written out here (per the
+    # chart's documented dind template) with the /sites NFS volume added to
+    # the runner container.
     template:
       spec:
+        initContainers:
+          # Seed the runner's externals into a shared volume so the dind
+          # sidecar and runner agree on hook tooling.
+          - name: init-dind-externals
+            image: ghcr.io/actions/actions-runner:latest
+            command: ["cp", "-r", "/home/runner/externals/.", "/home/runner/tmpDir/"]
+            volumeMounts:
+              - name: dind-externals
+                mountPath: /home/runner/tmpDir
+          # Native sidecar (restartPolicy: Always) running the Docker daemon.
+          - name: dind
+            image: docker:dind
+            args:
+              - dockerd
+              - --host=unix:///var/run/docker.sock
+              - --group=$(DOCKER_GROUP_GID)
+            env:
+              - name: DOCKER_GROUP_GID
+                value: "123"
+            securityContext:
+              privileged: true
+            restartPolicy: Always
+            startupProbe:
+              exec:
+                command: ["docker", "info"]
+              initialDelaySeconds: 0
+              failureThreshold: 24
+              periodSeconds: 5
+            volumeMounts:
+              - name: work
+                mountPath: /home/runner/_work
+              - name: dind-sock
+                mountPath: /var/run
+              - name: dind-externals
+                mountPath: /home/runner/externals
         containers:
           - name: runner
             image: ghcr.io/actions/actions-runner:latest
             command: ["/home/runner/run.sh"]
+            env:
+              - name: DOCKER_HOST
+                value: unix:///var/run/docker.sock
+              - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
+                value: "120"
             volumeMounts:
+              - name: work
+                mountPath: /home/runner/_work
+              - name: dind-sock
+                mountPath: /var/run
+              # Shared NFS export served by nfs-server (storage namespace);
+              # build jobs publish their dist/ output straight onto the volume
+              # nginx serves.
               - name: sites
                 mountPath: /sites
             resources:
@@ -64,9 +113,12 @@ spec:
               limits:
                 memory: 2Gi
         volumes:
-          # Shared NFS export served by nfs-server (storage namespace); build
-          # jobs publish their dist/ output straight onto the volume nginx
-          # serves.
+          - name: work
+            emptyDir: {}
+          - name: dind-sock
+            emptyDir: {}
+          - name: dind-externals
+            emptyDir: {}
           - name: sites
             nfs:
               server: nfs-server.storage.svc.cluster.local

--- a/kubernetes/apps/tools/actions-runner-controller/runner/app/secret.sops.yaml
+++ b/kubernetes/apps/tools/actions-runner-controller/runner/app/secret.sops.yaml
@@ -5,20 +5,17 @@ metadata:
     namespace: tools
 type: Opaque
 stringData:
-    #ENC[AES256_GCM,data:nInKU9O1nPh2uvLe5OeFJweNt9KtR4K36TItktkCy4S0TfvuD75X9NKRZICcBI3l29+6le11d6+dJ35ahQeF0FLkYEw0xC3s,iv:oJ6OT+NIdJ4hLN8bNaYdnHSqH4+rproQPGSr+815oDI=,tag:FhCxOOKu+MRmelfG/PqF4w==,type:comment]
-    #ENC[AES256_GCM,data:HzC4p6mkS+cBEpwvJK0AvUCQSQbMtGO+YajzRvSRFt2Yrfla12Cv+WBeIFJ6P7G1AD4907WQ3wUrDb1Tp8elY8fNMyaDbRSNIpuMjQ==,iv:pUcb6kVTBwV/aMRciK55Rvdow2fYFx5WmCv7FjrCtKU=,tag:aYTzYeQd4kR0Ikf2TRC6Rw==,type:comment]
-    #ENC[AES256_GCM,data:+KAX0rOiNJ6o8CF6+/SOc4jxX+1Q7PGozhf9+90QGqmfBvd7agzcErl5Si+wJUx5MBzON3yZ5ribT1k=,iv:ZQlwJVGAHC1OY/qrbHbttghRiK/4GvPdYvkTsk0euIk=,tag:Cxn6dS1/dmMCMG9BK68jXQ==,type:comment]
-    #ENC[AES256_GCM,data:AtejOzGdto2p3OfPQ4PEKdo4gCb6D9MPatfvNRhOtXKgI6aamIDRb6CoRVJn,iv:3aFQfOp0jpqhIfqx1TsaZ39Uc7T2QDzVjROHVGbATPw=,tag:qe/p8KzFb0x55an/F3f0+w==,type:comment]
-    #ENC[AES256_GCM,data:bDs5FveT/fDKwQZYetFDP+WfTQgN,iv:2ZWJtiSJ88w885EEKcJUsFrlRd5gP4FR5jTcbrutAOo=,tag:VEfOB52FuAYN1uAQEWyoqA==,type:comment]
-    github_app_id: ENC[AES256_GCM,data:OMKKg4EZ4uTbfl4FJxsGwQY=,iv:+TepKQovp0rt4KOG/cftH/GdjBYTO39AdmZ1r0lGLfo=,tag:TfGgk3iFg5m7K47YzM4iSQ==,type:str]
-    github_app_installation_id: ENC[AES256_GCM,data:2heFamJ1s7EvcO7X22NOU+CZE1GbMYJUO2o=,iv:n9E3/HiLaXb7HRm+PNuYjSHcgbz87jlJkv+Qs3mScYg=,tag:sQZc/XhPtay6xvTkBqxxAg==,type:str]
-    github_app_private_key: ENC[AES256_GCM,data:3JE95Jv9AG1VVrLwgDMI4SotaP4VJFbRmorBre4a1UTjHnMWe2xfd9YQTnRdwwlqHqfMZ+tEO9skikM8Aiy/DrxCqQE9dI0AcW3LKpxFiQ5QVKcBmA==,iv:cBUfYwjNbmL9NIQVnP7/kj8f5bmF7FANBQLT+6MdfjA=,tag:RKs+FWBhvaw71g8yxaGAhQ==,type:str]
+    #ENC[AES256_GCM,data:OZKlp+HD5SMF0OKH7GCb1HSbLU9c5ZFizq9IFaO3cfoAJhnJ0AgQDW2+EeG053SVDxXlpz4UATNDtuO1FQ==,iv:QB3CLRmnL3PDLKh1dA92iN6I5YO6GFKnUyUzbeeCErU=,tag:eyKoii+C+fSEeP93oqVrsQ==,type:comment]
+    #ENC[AES256_GCM,data:5khoMTr/kaGcLJcf81kjC7kzi2xeEe0UNRFV0fRMdaETXuHerB1ah4d9aTsmwYQkwiEsQc79/tFtU5vtOGEbaOhf6IZ1BIqSdw==,iv:oBhNjnuKO8OMu+2OUg7ffeTaXCkAJxNbOslLk7DKLJQ=,tag:zoCc+T4tR7yu+X4p1IXyxg==,type:comment]
+    github_app_id: ENC[AES256_GCM,data:4y9evIC++A==,iv:KkNc+X5GGbLsc8QdoWLrq4F4JdjP/es4TW7zmtMBjZk=,tag:v2KtKalmILf/hY27AFVYFg==,type:str]
+    github_app_installation_id: ENC[AES256_GCM,data:LDuJCX2p8K/+,iv:AnMCiyPvBiz1mnqH2ftYxxUuVp6jmJnihcaPY/aUfNo=,tag:97MRiKB/Du3gEQwxumfHMg==,type:str]
+    github_app_private_key: ENC[AES256_GCM,data:u5TAItvXhaYEIiyzKMz4jQ/t4xXfN/irPEHpaZQ+M1UHWodJpXSDME35CZT1jCBV6smssICv/V5hQicWUwx2on3Dn8mlP5PXKrTOTy1SlnVhbteQQKliEQv5AKFsqVs/Gh+ZVmfCqjkAJGPbcGhMAMjruj8RpTZokc7SOdaielttPCQMFRzrpXnol9lkAFp6r1weLjM1QJArEEEmA/y+EWBW+vHwXuTV7AlyMsDN9OGxRixgNVwDzfktSJ7VidcSg5qTt7VWrmj76SPzQOdB3/eDq7GfPdUTHN/LBZxVkmNTEgC1Dj/wotnwIHJ090LbTGk5Qi/K4mL3PYi9q+XvOXXYO8EtFljdyAb+NJKagDtoxwNUUpa9u8Gpvt6cWrb07i961XYbLo13yCJBIIGcHc1ej0Cov6npvhWaNfQy3vUCg/XdiZajxg1sNb1KoZqRlNuDv9weQ3ZjcfjivwzDtxXuwPdJxYszbj4bTo+r4AXolHfTpziKZmvFGXBcUci/9uB1CSQKsO3PeN6TCb/UTOKa8WQzs2qB9Q+L/1MmQSm+bMbJ8TMy8aUEeFCQc6UI56mxhP5oH8XRZiQLy+rXINKxzhvzv3WzflgL1bwYKbjhtwt0eHBy115NtpjbfiH1ujfYurL1/LSILZdiKUASAB1DTeX3TPMtfaD5UjqCp9wc/aT/scTad6dU5PzTIqeo3hEYD6bwF7GqDv73whmBSzeJSr6DoS/oE/uUPcn6QWzQOCG5WkVafoJZ3PR9MzbPRUcwROUYcgx9DxSjWAihu79tsiD7zUAZJ6Wgokgb3Pe/4p5o7l2kgRGyOrQSo5JcMyCbm4GGeeqD0v3VQGIHCK39MLLktY+B0MQOUvyMClPYUSJuS+Au9C5V67F9338KWni70MbpybaQP5q0HNO4fHR129o8gd5yGwRzLf65D0Fxn1famHKmjip+tXXTMhSWfvNYFhXMIhcpFORNfEs5uMTd7NUmyjngcMsBMHeoVIVPXGmRb0JQIfZanLjFu4QifTiswtVEjylI8OemiNeM7JVOriSFgOffa+fbvOUIX9VR2M8lVOPeT/u0Sd/MrojlM3xF9d+TnUJFOHwcIGzdT5t5YZXryGcSUo0Cgl7cz4DaomwruQS2UIinnXvUHo5yUL27A1AKUMbnZKr6Lo5bva7hxE5/hzYNqg4ZBEc+LIEHYBFspkPk3Y4NXhuTX0uNeVhk1yYDlnIc3ofmmtu4PBFciUvi51R7XNS86e7FpexKQrEu5T59sJER9Bxl8AhTPpS2kMO4YyEdBkPsuCrOFyLGEH4lAtyJ6GjkOBrdoJ3ydu4cMbmFplFD0OtScEGZuA+3zgl5el5kTr7mxckAqwzq3w3EbuIp8r2SlAUOBTUfq1bTQWaz8OGXzKr7ucFpZxR3gEAg6dj/7Qr5InJzUGbmW4z5Jz7jrSfAULLKbDuDkewIbrFyw/pr5SggHPDeQbaxi0U8djbMK4xORZtX7UC1G6n6juSd12ZHVzgVLd1Iqg/7+esS4iexsYuYCQ+jAiMPyX799LcmkK4JbniuDBwjojRYiLKNL4oqNsnlHKFVgDnZfoEiSye8PWadcz9UAL7uRJ13XmCHWJJqB1YMAP1KfPunmmiQxZhseT9z0zpyqmrGUwZzgVYLuLCQFVRKKVt3vXOfVdFF9EU9CfeR/zUfs9cjY1/RSikbZkXTorugQWr9+0oA1Ia7zuNjj0BCSGUr6c2JO15Vddx/yB0xsweM7pPurG3TLwTIOB9SNJqr9s+vH73734j8KQHsI0I/zJ2ZZKM8+O9hf2Ug0laZtXZx8owBtq9wJj2N5kUOU+gNbu1i1tyoctQsAJW9C/HU13HSLE5IBnIkgI3vQbGojmaF8Q5w9g+7dd+IivhLC/xXud6Ap/h5JPfx4GClubqlfc8KPwD1H3QOtFokFSXZKs+F2Jhav9IM/yDT1SLf6WSn1OH5D1FefZCbtBVVa9VUX/fTbqswpnU1BIV96hUSCIgbJxtZ5Sda1NoGIDDQrXfQ/J5Jr315NJOb53DlqUushl7AENWlPCOaYaOoFa0MjLlo162c1tUMqcQeN9L1DBioFrR1XisrwyivGvrur5q3MebsE+vBDJqWMaDVmltW2DBmP5fF5cMKnS3aA8WWFhSMHQeRNwJjoEGNZqDEdaZY9HOskD0qZlO1NC3KYU7j1NZJxz9I8dFdH2aZuQepQujhjUN+yi9nnJC/AEQ5E3Y=,iv:Dcjl0sZPDj7R4wUTLlK51aJ/T9jA7R0Qun3iFl7R0Ww=,tag:K14PHPvIGwbwlCL2e+ehUw==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-west-2:654654220436:key/mrk-74c4597ebffd41d38a852228e13d76cc
           role: arn:aws:iam::654654220436:role/iam-role-sops
-          created_at: "2026-06-01T04:16:54Z"
-          enc: AQICAHhNDAK0Is+rGNAlNYnav2FEvs37O7WQwrCmqkcTMDWNIQGKa0MNNzUMloA7Hi01fuXMAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMofrXC0KZjcPDuUT/AgEQgDsJqoz5VuQhB6MtsUvLbZ5FXUgh2SpFaG2aBlLeKr0UMW7ZmQdXAXD8mgjxw3IpOi/BUP/dASg/BfI6Hg==
+          created_at: "2026-06-01T05:01:35Z"
+          enc: AQICAHhNDAK0Is+rGNAlNYnav2FEvs37O7WQwrCmqkcTMDWNIQFlIAXqRuljA6o7iq3uRGx7AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMCOb2mJp0RZzidb4fAgEQgDsa6lwb96oWqKCveuN4KYtzxbbUsqfKGubCUHuP92KZ0BaVNNar9EMNPPDCRCr2bXEBZZ9z7H267M+byw==
           aws_profile: ""
     gcp_kms: []
     azure_kv: []
@@ -27,32 +24,32 @@ sops:
         - recipient: age1mzxwncaj0364q8jxfj0y73ptt63czwxucf9lrnn28c7kwyr5wfdsj9gsk2
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaTU1wM1dld3A5eDREZlRG
-            U1FmekRoWDRzUHRjL3lWaUQ3NW80QS9pVmdzCkRLNlI2eGdXbUR3TVZOZDRrZjQ3
-            eFh5ZUNFOTVqQ0h4WVNFOWhEb2t2czQKLS0tIGdFMXp6Y205ZTNGMjVGTzI2U1Jt
-            NUFrbzZlQkZPSVNoR1dKZXVuQ1ZuWDgKfYwRyOaHCHm5cgoo805FbXwG3I8734gG
-            NEqLZUIc9eWKVWO2gfJVRPlWW6blsLYF4DPRoW8XLWALyFa8Tgi4/A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiZG91VHl3bmVYaFg5L0x1
+            RmhXR2Mwd09ZRjNLelJZL2o2WThUUm1YekZrCjIrNEZMUVNIRC8vbUtDY0V6cFhv
+            RkZRK2lDU1g5WDI4R2JDSUVjSEx0Y2cKLS0tIFZxM3RSOGJOUS81ZTJEYThqWDNO
+            MzZlUU5PZGZXNkplbDh0VEFVZFFGVncKjT8kvzGHK6jMUBvVgeQIrM/tX1uht+SQ
+            w8mWFv0kcawwTrWwLdlVDJBtWbozhdfvxXxzw1buAa9N5RCXsCnZag==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age12uckcdwv9p2s75ae3h20wgn70taatdzzl44n9x6vr8h9qurzkaqqkhphz7
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuYVpET2pPYnFuQkF1clZk
-            dWkrcWpCcDVCZnJWVEwzSWpKMHJpN0NDK0MwCkIvMHVmZkNOOU1KNGJ5cTNsb0Fr
-            aUNpbit2NThsUU10bHVia2xvTUk1RW8KLS0tIEgyU21zd1d2WEVNWFF1STFwOFhw
-            Y2U1R3JOMCt2R2h4UjlVTnVTelF0Z0UKo+xIDX17RxHptH4jr213VdmQ9JB0zmg2
-            oizoFTvhiVXuBfxkHXTFgksVs8akbra1ovYeMIZ5Q9Tqz1RVWeyfQQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiUHhhNHlkVVozbERKMXZO
+            ZkVWN3dSclZaRnBCa2lOQU9INVVJd2M0OW5nClBIWW5VdHVHTlBESW9uYjI1V2pa
+            RkJmVmJYc1IxakJaME9DbVBnOTJOSVkKLS0tIENOc1lsbHJiWTlmVUdqS2JyU1RM
+            NlZEZVRISmVhaEpJb0RsZlBKTjNndlUKByRu+HNaizXNEuyum+OEbNIObnd+hwZY
+            +xsSNWRba3bugiHCyiOzRs0c4ZXdMf7PqN260ULVjZN1LMJw72e0Cg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hmmuna95ktwl9sf9j56wjjukyf22ukdyjd8c47nlf5fjgyeyk5rsmhtyjx
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtNWJkbDJsd0NQeGxnSE1F
-            aGt4SjVFd3VwUmJrK1BxTlk0b2k2anZ1dkZZCmV3blIzV0prc3phb0FrVDB5MndU
-            MnAyMk1NM1hoempMbVFMNVFJeVhocVkKLS0tIFI4RHl2UHd0UThlMC84M0UwWWxx
-            SWZLMHVYK2x1L0wrMUs0Tm4yQ3lOSVkKDMfwvSlBYPia+A0Y1X8S9s857w1+51hs
-            uCdnhG712O8BbnZ7WSeBBFDUdcHxvrDJ2/WjeIWykYkMrVXV/byjHg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmZUg5M1hXUUpWdjRoZHRW
+            MHBzZWx5RlpPbFdKK1J5VkpmREtZUGVYekRZCnJvWWtrU3FnS013Tm5NT0JtL0Fh
+            TzZGRUhJTXQ2cTNyTFg3Y1llS295SWsKLS0tIEJNS0ljdDk3M2FBVlluMld1QjdD
+            NWEzTHBiRmpVRFRocDZOOTlTUDlUZ3cKOG3KwVMQRtAbQV/HwRUf4OiCBrlz/hZC
+            Fi70FdDgYhzrJDal5txJxZZ7GJMOvBFvRGUnpI+iaGH6BbqS7gRcSQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-01T04:16:55Z"
-    mac: ENC[AES256_GCM,data:Di1fTBx9y5yC6x24ltSBgf2i7kvXpzExPakLLCXEy0pI7O3v+wpABacBp6M+4QxQmQutELc/PNbRDl8S7q4c18INVev7Yuxf2oCh73kX6C8cDkQJo+yrk2tVyJB4EWQ24muoNerkdEN535uTj8YmDAk9b/eVh+sehnQ2U3HyuHY=,iv:gMuIKFKiN9jJ1C31H/aEl7AfUXGhPLfAtjxkDP+a3vU=,tag:EWaJh3T0PWkCvRxoE9Wfbg==,type:str]
+    lastmodified: "2026-06-01T05:01:36Z"
+    mac: ENC[AES256_GCM,data:Yw9pfFDfuf/Dgr4wbziYEjeDt3Tzacmovuf1km/SigsEV9Dls82fL6Kk3gnNQLzMKlHSK/bFxDWLVCKjPuH5xMpasHiPMiPxEEoK5rXpz6aHA1zkDU1JghIBKsTm6sKxXg0JEkZ+xnyijmfAeNXDIZ0tyjbUjHpqPYU1UwqnPbE=,iv:OwDcLl3rnkR32ouKcPdicoF2MujOlSW34siZRu1VPoo=,tag:iyCadegiV/06LP4DVpYlDg==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.7.3


### PR DESCRIPTION
## What

Two changes that make the `sites-builder` runner actually functional:

1. **Docker-in-Docker** — the runner can now run container-based build steps.
2. **GitHub App secret populated** — real credentials for the `tnwks-sites-runner` App.

## dind

The chart's `containerMode: dind` convenience shortcut **cannot** be combined with a custom `template`, and we need a custom template for the `/sites` NFS mount. So the full documented dind pod spec is written out explicitly:

- `init-dind-externals` initContainer (seeds runner externals into a shared volume)
- `dind` native sidecar (`restartPolicy: Always`, `privileged: true`, runs `dockerd` on a unix socket, `docker info` startup probe)
- `work` / `dind-sock` / `dind-externals` emptyDir volumes
- runner container gets `DOCKER_HOST=unix:///var/run/docker.sock`, `RUNNER_WAIT_FOR_DOCKER_IN_SECONDS=120`, the dind socket mount, **and** the `/sites` NFS mount

## Secret

`sites-runner-github-app` is filled with the real GitHub App credentials:
- `github_app_id: 3927395`
- `github_app_installation_id: 137113660`
- `github_app_private_key`: the App's RSA private key

sops-encrypted with the **AWS KMS key + 3 age recipients** (matches the rest of the repo). The committed diff contains only `ENC[...]` ciphertext — no plaintext.

## Validation

- `kustomize build` of the runner app ✅
- `helm template` of the runner chart with these values renders cleanly (EXIT 0): `AutoscalingRunnerSet` with the dind sidecar (`privileged: true`, `DOCKER_HOST` socket, `restartPolicy: Always`) and the `/sites` NFS volume.
- Decrypted secret round-trips: `github_app_id`/`installation_id` correct; private key parses (via real YAML parser) to **`RSA key ok`** and is byte-identical to the source PEM.

After merge + reconcile, the runner registers with `iT3E/tnwks-sites` as scale set `sites-builder` and is ready to pick up `runs-on: sites-builder` jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
