### PR TITLE
feat(sites): wire the sites platform into the WSL cluster overlay

### DIFF
--- a/kubernetes/apps/tools/namespace.yaml
+++ b/kubernetes/apps/tools/namespace.yaml
@@ -5,3 +5,7 @@ metadata:
   name: tools
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # The sites-builder ARC runner uses a Docker-in-Docker sidecar
+    # (securityContext.privileged: true), which PSA baseline forbids.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/kubernetes/clusters/wsl/apps/kustomization.yaml
+++ b/kubernetes/clusters/wsl/apps/kustomization.yaml
@@ -37,6 +37,14 @@ resources:
   - ../../../apps/monitoring
   - ../../../apps/selfhosted
   - ../../../apps/tools
+  # Sites platform — WSL-only. The NFS server gives nginx + the GHA runner a
+  # shared RWX volume on top of WSL's RWO-only local-path. On MS-01 this would
+  # be CephFS RWX instead, so it's wired per-cluster rather than in the shared
+  # groups. (nginx itself lives in the production overlay below.)
+  - ../../../apps/storage/namespace.yaml
+  - ../../../apps/storage/nfs-server/ks.yaml
+  - ../../../apps/tools/actions-runner-controller/controller/ks.yaml
+  - ../../../apps/tools/actions-runner-controller/runner/ks.yaml
 
   # Trimmed namespaces — per-namespace overlays sit alongside this file
   - ./home-automation

--- a/kubernetes/clusters/wsl/apps/production/kustomization.yaml
+++ b/kubernetes/clusters/wsl/apps/production/kustomization.yaml
@@ -18,6 +18,10 @@ resources:
   - ../../../../apps/production/ombi-f/ks.yaml
   - ../../../../apps/production/wizarr/ks.yaml
   - ../../../../apps/production/changedetection/ks.yaml
+  # sites: nginx serving AI-built Angular frontends at sites.tnwks.us/<project>/
+  # off the shared NFS export (nfs-server lives in the storage namespace, wired
+  # in the WSL apps overlay one level up).
+  - ../../../../apps/production/sites/ks.yaml
   # frigate: WSL-specific Flux Kustomization with a patch to replace the
   # NFD coral nodeSelector with a hostname pin to homelab-wsl-worker-2.
   - ./frigate-ks.yaml


### PR DESCRIPTION
## What

Wires the sites platform into the WSL cluster overlay so it actually deploys. The manifests were merged (#1283/#1284/#1286) but nothing referenced them, so `flux get kustomizations` showed no sites/nfs/runner and the `sites`/`storage` namespaces didn't exist.

## Changes

- **`wsl/apps/kustomization.yaml`** — add the `storage` namespace + `nfs-server` ks, and the `actions-runner-controller` controller + `sites-runner` ks.
- **`wsl/apps/production/kustomization.yaml`** — add `sites` (nginx) alongside the other production apps.
- **`apps/tools/namespace.yaml`** — add `pod-security.kubernetes.io/enforce: privileged`.

## Why per-cluster (not shared groups)

The NFS server exists to provide **RWX** on top of WSL's RWO-only `local-path`. On MS-01 that role is **CephFS** instead, so the sites platform is wired in the WSL overlay rather than the shared `apps/` groups — same pattern as `flannel`/`frigate` (WSL-specific) vs the shared bits.

## Why the privileged PSA label on `tools`

The `sites-builder` runner uses a **Docker-in-Docker sidecar** (`securityContext.privileged: true`). The `tools` namespace had no PSA label, so it inherited the Talos cluster default — **`baseline:latest`** — which forbids privileged. Verified by admission dry-run:

```
$ kubectl apply --dry-run=server (privileged pod in tools)
Error: violates PodSecurity "baseline:latest": privileged ... must not set securityContext.privileged=true
```

This mirrors the `production` namespace, which already enforces `privileged` for frigate's Coral TPU. (Both are shared-namespace labels driven by WSL-only workloads — established convention in this repo.)

## Validation

- `kustomize build --load-restrictor LoadRestrictionsNone kubernetes/clusters/wsl/apps` ✅ (73 docs; the load-restrictor flag is what Flux uses — these overlays reference sibling `ks.yaml` files by design).
- All four Flux Kustomizations (`nfs-server`, `sites`, `actions-runner-controller`, `sites-runner`) render exactly once.
- `storage` and `tools` namespaces both carry `enforce: privileged` in the build output.

## Expected reconcile order after merge

`nfs-server` → `actions-runner-controller` (controller) → `sites` + `sites-runner` (both `dependsOn` nfs-server; runner also `dependsOn` the controller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
