### PR TITLE
fix(sites): pin nfs-server to worker-2 so its local-path PVC provisions

### DIFF
--- a/kubernetes/clusters/wsl/apps/kustomization.yaml
+++ b/kubernetes/clusters/wsl/apps/kustomization.yaml
@@ -42,7 +42,9 @@ resources:
   # be CephFS RWX instead, so it's wired per-cluster rather than in the shared
   # groups. (nginx itself lives in the production overlay below.)
   - ../../../apps/storage/namespace.yaml
-  - ../../../apps/storage/nfs-server/ks.yaml
+  # nfs-server: WSL-specific ks with a nodeSelector pin to worker-2 (the only
+  # node local-path can provision on). See nfs-server-ks.yaml.
+  - ./nfs-server-ks.yaml
   - ../../../apps/tools/actions-runner-controller/controller/ks.yaml
   - ../../../apps/tools/actions-runner-controller/runner/ks.yaml
 

--- a/kubernetes/clusters/wsl/apps/nfs-server-ks.yaml
+++ b/kubernetes/clusters/wsl/apps/nfs-server-ks.yaml
@@ -1,0 +1,40 @@
+---
+# WSL overlay for nfs-server: pin the pod to homelab-wsl-worker-2.
+#
+# The `local-path` StorageClass on WSL is configured with an explicit
+# nodePathMap that only lists worker-2 (path /mnt/e/k8s-storage/default) and
+# has no DEFAULT_PATH_FOR_NON_LISTED_NODES, so its PVC can only be provisioned
+# on worker-2. Without this pin the scheduler may place the pod on worker-1 and
+# provisioning fails with "config doesn't contain node homelab-wsl-worker-1".
+#
+# Only the nfs-server pod (which owns the local-path PVC) needs the pin —
+# nginx and the runner reach the share over the network via the Service.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: nfs-server
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/storage/nfs-server/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: nfs-server
+      namespace: storage
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  patches:
+    - target:
+        kind: Deployment
+        name: nfs-server
+      patch: |
+        - op: add
+          path: /spec/template/spec/nodeSelector
+          value:
+            kubernetes.io/hostname: homelab-wsl-worker-2


### PR DESCRIPTION
## What

Pins the `nfs-server` pod to `homelab-wsl-worker-2` so its `local-path` PVC can actually provision. Fixes the deploy from #1287.

## Why

After #1287 wired the sites platform in, `nfs-server` stuck in `Pending`. Root cause was the WSL `local-path` provisioner config, not the manifests:

```
ProvisioningFailed: failed to provision volume with StorageClass "local-path":
config doesn't contain node homelab-wsl-worker-1, and no
DEFAULT_PATH_FOR_NON_LISTED_NODES available
```

The `local-path` StorageClass's `nodePathMap` lists **only** `worker-2` (`/mnt/e/k8s-storage/default`) with no default fallback. The scheduler put nfs-server on `worker-1`, so provisioning failed.

## Fix

New WSL-specific `nfs-server-ks.yaml` patches a `nodeSelector` hostname pin to `worker-2`, and the WSL overlay references it instead of the shared (unpinned) `nfs-server/ks.yaml`. Same pattern as `frigate-ks.yaml`.

Only the nfs-server pod (the PVC owner) needs the pin — nginx and the runner reach the share over the network via the Service, so they stay schedulable anywhere.

## Validation

- `kustomize build --load-restrictor LoadRestrictionsNone kubernetes/clusters/wsl/apps` passes; the `nfs-server` Kustomization carries the nodeSelector patch; the unpinned variant is no longer referenced.
- Will confirm the pod reaches `Running` + PVC `Bound` live after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
