### PR TITLE
fix(sites): use userspace nfs-ganesha instead of kernel NFS

### DIFF
--- a/kubernetes/apps/production/sites/app/deployment.yaml
+++ b/kubernetes/apps/production/sites/app/deployment.yaml
@@ -55,9 +55,9 @@ spec:
       volumes:
         - name: sites
           nfs:
-            # nfs-server Service in the storage namespace exports / (fsid=0).
+            # nfs-server (ganesha) in the storage namespace exports /export.
             server: nfs-server.storage.svc.cluster.local
-            path: /
+            path: /export
             readOnly: true
         - name: nginx-config
           configMap:

--- a/kubernetes/apps/storage/nfs-server/app/deployment.yaml
+++ b/kubernetes/apps/storage/nfs-server/app/deployment.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: nfs-server
 spec:
-  # NFS state (the exported /sites tree) lives on a single RWO PVC, so this
-  # must stay single-replica — Recreate avoids two pods racing for the volume.
+  # NFS state (the exported tree) lives on a single RWO PVC, so this must stay
+  # single-replica — Recreate avoids two pods racing for the volume.
   replicas: 1
   strategy:
     type: Recreate
@@ -22,44 +22,43 @@ spec:
     spec:
       containers:
         - name: nfs-server
-          # erichough/nfs-server — ganesha/kernel NFS server. Exports each
-          # directory listed in NFS_EXPORT_* env vars; rw + no_root_squash so
-          # the actions-runner can write build output as any uid.
-          image: docker.io/erichough/nfs-server:2.2.1
+          # Userspace NFS-Ganesha (vfs FSAL) from the kubernetes-sigs
+          # nfs-ganesha-server-and-external-provisioner project. Runs entirely
+          # in userspace — no host nfsd kernel module (unlike erichough /
+          # volume-nfs), which WSL2's Talos-in-Docker kernel doesn't load.
+          # Exports /export over NFSv4 on 2049. v4.0.8 is the newest tag
+          # actually published to registry.k8s.io (master references an
+          # unpromoted v6.5).
+          image: registry.k8s.io/sig-storage/nfs-provisioner:v4.0.8
+          args:
+            # The binary doubles as a dynamic provisioner; the arg is harmless
+            # for our static single-export use and keeps ganesha's default
+            # NFSv4-only export of /export.
+            - "-provisioner=tnwks.us/nfs"
           env:
-            - name: NFS_EXPORT_0
-              value: "/sites *(rw,fsid=0,sync,no_subtree_check,no_root_squash,insecure)"
-            # nfsd thread count; the default of 8 is plenty for a single
-            # nginx reader plus the runner.
-            - name: NFS_SERVER_THREAD_COUNT
-              value: "8"
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           ports:
             - name: nfs
               containerPort: 2049
               protocol: TCP
-            - name: mountd
-              containerPort: 20048
-              protocol: TCP
-            - name: rpcbind
-              containerPort: 111
-              protocol: TCP
+            - name: nfs-udp
+              containerPort: 2049
+              protocol: UDP
           securityContext:
-            # NFS kernel server needs SYS_ADMIN (mount namespaces, nfsd) and
-            # access to the host's nfs/nfsd kernel modules — privileged is the
-            # documented requirement for this image.
-            privileged: true
+            # Userspace ganesha needs no privileged/kernel modules — only:
+            #   DAC_READ_SEARCH — traverse/read exported files regardless of
+            #                     perms (ganesha does its own NFS access checks)
+            #   SYS_RESOURCE    — raise the fd rlimit for many clients
             capabilities:
               add:
-                - SYS_ADMIN
-                - SYS_MODULE
+                - DAC_READ_SEARCH
+                - SYS_RESOURCE
           volumeMounts:
             - name: data
-              mountPath: /sites
-            # erichough/nfs-server loads nfs/nfsd modules from the host's
-            # kernel module tree at startup.
-            - name: kernel-modules
-              mountPath: /lib/modules
-              readOnly: true
+              mountPath: /export
           resources:
             requests:
               cpu: 25m
@@ -70,6 +69,3 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: nfs-server-data
-        - name: kernel-modules
-          hostPath:
-            path: /lib/modules

--- a/kubernetes/apps/storage/nfs-server/app/service.yaml
+++ b/kubernetes/apps/storage/nfs-server/app/service.yaml
@@ -10,16 +10,15 @@ spec:
   type: ClusterIP
   selector:
     app.kubernetes.io/name: nfs-server
+  # NFSv4-only: clients reach the server on 2049 alone. Ganesha starts rpcbind
+  # internally but NFSv4.1 clients never need it, so mountd/rpcbind aren't
+  # exposed.
   ports:
     - name: nfs
       port: 2049
       targetPort: nfs
       protocol: TCP
-    - name: mountd
-      port: 20048
-      targetPort: mountd
-      protocol: TCP
-    - name: rpcbind
-      port: 111
-      targetPort: rpcbind
-      protocol: TCP
+    - name: nfs-udp
+      port: 2049
+      targetPort: nfs-udp
+      protocol: UDP

--- a/kubernetes/apps/tools/actions-runner-controller/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/actions-runner-controller/runner/app/helmrelease.yaml
@@ -122,4 +122,4 @@ spec:
           - name: sites
             nfs:
               server: nfs-server.storage.svc.cluster.local
-              path: /
+              path: /export


### PR DESCRIPTION
## What

Replaces the kernel-NFS server image with a **userspace nfs-ganesha** image so the NFS server actually starts on WSL.

## Why

After the platform deployed, `nfs-server` (erichough/nfs-server) crash-looped:

```
ERROR: nfs module is not loaded in the Docker host's kernel (try: modprobe nfs)
```

erichough/nfs-server — and `registry.k8s.io/volume-nfs` — run the **kernel** NFS server, which needs the host's `nfsd` module loaded. WSL2's Talos-in-Docker kernel doesn't load it, and `modprobe`-ing it on the host is a manual, non-persistent mutation outside GitOps.

## Fix

Switch to **`registry.k8s.io/sig-storage/nfs-provisioner:v4.0.8`** (the kubernetes-sigs nfs-ganesha image). It runs Ganesha entirely in userspace (vfs FSAL):

- **No host kernel module**, **no `privileged`**, **no `/lib/modules` hostPath**.
- Only caps `DAC_READ_SEARCH` + `SYS_RESOURCE`.
- Exports **`/export`** over **NFSv4** on **2049**.
- `v4.0.8` is the newest tag actually published to `registry.k8s.io` (the repo's `master` references an unpromoted v6.5).

### Changes
- **deployment** — ganesha image + args, drop privileged/SYS_ADMIN/SYS_MODULE and the kernel-modules hostPath, add `POD_IP`, export dir `/export`.
- **service** — NFSv4-only: keep 2049 (tcp/udp), drop rpcbind(111)/mountd(20048). NFSv4.1 clients don't need portmapper.
- **consumers** — nginx and the runner now mount **server path `/export`** (was `/`). In-pod mountPaths (`/usr/share/nginx/html`, `/sites`) are unchanged, so the `tnwks-sites` build workflow needs no change.

## Validation

- `kustomize build` ✅ for nfs-server, sites, runner, and the WSL apps overlay.
- Will confirm the pod reaches `Running` (no kernel-module error) and that nginx mounts the share, live after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
