### PR TITLE
fix(sites): nfs-ganesha serves — VFS on ext4, fixed ClusterIP, node DNS

### DIFF
--- a/kubernetes/apps/production/sites/app/deployment.yaml
+++ b/kubernetes/apps/production/sites/app/deployment.yaml
@@ -55,8 +55,10 @@ spec:
       volumes:
         - name: sites
           nfs:
-            # nfs-server (ganesha) in the storage namespace exports /export.
-            server: nfs-server.storage.svc.cluster.local
+            # nfs-server (ganesha) fixed ClusterIP — referenced by IP, not DNS,
+            # because the kubelet-level NFS mount uses the node resolver, which
+            # can't resolve cluster service names. See the Service manifest.
+            server: 10.43.255.254
             path: /export
             readOnly: true
         - name: nginx-config

--- a/kubernetes/apps/storage/nfs-server/app/configmap.yaml
+++ b/kubernetes/apps/storage/nfs-server/app/configmap.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nfs-ganesha-config
+  namespace: storage
+data:
+  # Static NFS-Ganesha config. The nfs-provisioner image's built-in config only
+  # exports a metadata-only PSEUDO root (it's meant for dynamic per-PVC
+  # exports); we bypass the provisioner entrypoint and run ganesha.nfsd directly
+  # against this config to statically export /export over NFSv4, read-write.
+  ganesha.conf: |
+    NFS_CORE_PARAM {
+      # NFSv4 only — no rpcbind/mountd/NLM, so clients need just port 2049.
+      Enable_NLM = false;
+      Enable_RQUOTA = false;
+      Protocols = 4;
+      # The image has no kernel NFS; nothing else is listening, but be explicit.
+      NFS_Port = 2049;
+    }
+
+    NFSV4 {
+      # Shorter grace period — single server, no clustered state to recover.
+      Graceless = true;
+      # Pseudo filesystem root; the export below grafts in at /export.
+      Lease_Lifetime = 60;
+    }
+
+    EXPORT {
+      Export_Id = 1;
+      # Pseudo path clients mount: nfs:<ip>:/export
+      Pseudo = /export;
+      Path = /export;
+      Access_Type = RW;
+      Squash = No_Root_Squash;
+      # NFSv4 doesn't use the transport-level Sec by default; allow sys auth.
+      SecType = sys;
+      Protocols = 4;
+      Transports = TCP;
+      FSAL {
+        # Userspace VFS backend — serves a normal directory tree, no kernel nfsd.
+        Name = VFS;
+      }
+    }
+
+    LOG {
+      Default_Log_Level = WARN;
+    }

--- a/kubernetes/apps/storage/nfs-server/app/deployment.yaml
+++ b/kubernetes/apps/storage/nfs-server/app/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: storage
   labels:
     app.kubernetes.io/name: nfs-server
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   # NFS state (the exported tree) lives on a single RWO PVC, so this must stay
   # single-replica — Recreate avoids two pods racing for the volume.
@@ -23,30 +25,25 @@ spec:
       containers:
         - name: nfs-server
           # Userspace NFS-Ganesha (vfs FSAL) from the kubernetes-sigs
-          # nfs-ganesha-server-and-external-provisioner project. Runs entirely
-          # in userspace — no host nfsd kernel module (unlike erichough /
-          # volume-nfs), which WSL2's Talos-in-Docker kernel doesn't load.
-          # Exports /export over NFSv4 on 2049. v4.0.8 is the newest tag
-          # actually published to registry.k8s.io (master references an
-          # unpromoted v6.5).
+          # nfs-ganesha image — no host nfsd kernel module (unlike erichough /
+          # volume-nfs), which WSL2's Talos-in-Docker kernel can't load.
           image: registry.k8s.io/sig-storage/nfs-provisioner:v4.0.8
-          args:
-            # The binary doubles as a dynamic provisioner; the arg is harmless
-            # for our static single-export use and keeps ganesha's default
-            # NFSv4-only export of /export.
-            - "-provisioner=tnwks.us/nfs"
-          env:
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
+          # Bypass the provisioner entrypoint (it only exports a metadata-only
+          # PSEUDO root and needs cluster RBAC for dynamic provisioning we don't
+          # use). Run ganesha.nfsd directly against our static config instead.
+          command:
+            - /usr/local/bin/ganesha.nfsd
+            - -F # foreground
+            - -L
+            - /dev/stdout # log to stdout
+            - -p
+            - /tmp/ganesha.pid # default /usr/local/var/run/ganesha is not writable
+            - -f
+            - /etc/ganesha/ganesha.conf
           ports:
             - name: nfs
               containerPort: 2049
               protocol: TCP
-            - name: nfs-udp
-              containerPort: 2049
-              protocol: UDP
           securityContext:
             # Userspace ganesha needs no privileged/kernel modules — only:
             #   DAC_READ_SEARCH — traverse/read exported files regardless of
@@ -59,6 +56,9 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /export
+            - name: config
+              mountPath: /etc/ganesha
+              readOnly: true
           resources:
             requests:
               cpu: 25m
@@ -69,3 +69,6 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: nfs-server-data
+        - name: config
+          configMap:
+            name: nfs-ganesha-config

--- a/kubernetes/apps/storage/nfs-server/app/kustomization.yaml
+++ b/kubernetes/apps/storage/nfs-server/app/kustomization.yaml
@@ -4,5 +4,6 @@ kind: Kustomization
 namespace: storage
 resources:
   - ./pvc.yaml
+  - ./configmap.yaml
   - ./deployment.yaml
   - ./service.yaml

--- a/kubernetes/apps/storage/nfs-server/app/service.yaml
+++ b/kubernetes/apps/storage/nfs-server/app/service.yaml
@@ -8,17 +8,18 @@ metadata:
     app.kubernetes.io/name: nfs-server
 spec:
   type: ClusterIP
+  # Fixed ClusterIP. The `nfs:` volume type mounts at the kubelet/node level,
+  # and Talos nodes resolve via the host resolver (169.254.x) — NOT cluster
+  # CoreDNS — so a *.svc.cluster.local name can't be resolved for the mount.
+  # Nodes CAN reach ClusterIPs directly (verified), so consumers reference this
+  # stable IP instead of the DNS name. Picked from the top of SERVICE_CIDR
+  # (10.43.0.0/16), clear of the dynamic allocation range in use.
+  clusterIP: 10.43.255.254
   selector:
     app.kubernetes.io/name: nfs-server
-  # NFSv4-only: clients reach the server on 2049 alone. Ganesha starts rpcbind
-  # internally but NFSv4.1 clients never need it, so mountd/rpcbind aren't
-  # exposed.
+  # NFSv4-only over TCP: clients reach the server on 2049 alone.
   ports:
     - name: nfs
       port: 2049
       targetPort: nfs
       protocol: TCP
-    - name: nfs-udp
-      port: 2049
-      targetPort: nfs-udp
-      protocol: UDP

--- a/kubernetes/apps/tools/actions-runner-controller/runner/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/actions-runner-controller/runner/app/helmrelease.yaml
@@ -121,5 +121,8 @@ spec:
             emptyDir: {}
           - name: sites
             nfs:
-              server: nfs-server.storage.svc.cluster.local
+              # nfs-server (ganesha) fixed ClusterIP — referenced by IP, not
+              # DNS: the kubelet-level NFS mount uses the node resolver, which
+              # can't resolve cluster service names. See the Service manifest.
+              server: 10.43.255.254
               path: /export

--- a/kubernetes/clusters/wsl/apps/nfs-server-ks.yaml
+++ b/kubernetes/clusters/wsl/apps/nfs-server-ks.yaml
@@ -1,14 +1,20 @@
 ---
-# WSL overlay for nfs-server: pin the pod to homelab-wsl-worker-2.
+# WSL overlay for nfs-server: pin to worker-1 and back the PVC with
+# local-path-ext4.
 #
-# The `local-path` StorageClass on WSL is configured with an explicit
-# nodePathMap that only lists worker-2 (path /mnt/e/k8s-storage/default) and
-# has no DEFAULT_PATH_FOR_NON_LISTED_NODES, so its PVC can only be provisioned
-# on worker-2. Without this pin the scheduler may place the pod on worker-1 and
-# provisioning fails with "config doesn't contain node homelab-wsl-worker-1".
+# nfs-ganesha's VFS FSAL needs name_to_handle_at / open_by_handle_at on the
+# backing filesystem. The default `local-path` SC stores data under
+# /mnt/e/k8s-storage (a Windows DrvFs/9p bind-mount) which does NOT support
+# file handles — ganesha fails with "vfs_lookup_path: Could not get handle for
+# path /export, error Operation not supported (95)".
 #
-# Only the nfs-server pod (which owns the local-path PVC) needs the pin —
-# nginx and the runner reach the share over the network via the Service.
+# local-path-ext4 sits on a real ext4 VHDX (handle support) but is pinned to
+# homelab-wsl-worker-1, so the nfs-server pod must run there too. This is the
+# same DrvFs wall that pushes postgres onto local-path-ext4 (see
+# cluster-settings STORAGE_CLASS_DATABASE).
+#
+# Only the nfs-server pod (PVC owner) needs the pin — nginx and the runner
+# reach the share over the network via the fixed Service ClusterIP.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -37,4 +43,11 @@ spec:
         - op: add
           path: /spec/template/spec/nodeSelector
           value:
-            kubernetes.io/hostname: homelab-wsl-worker-2
+            kubernetes.io/hostname: homelab-wsl-worker-1
+    - target:
+        kind: PersistentVolumeClaim
+        name: nfs-server-data
+      patch: |
+        - op: replace
+          path: /spec/storageClassName
+          value: local-path-ext4


### PR DESCRIPTION
## What

Makes the in-cluster NFS server actually serve. Three issues surfaced during live bring-up; all fixed here. Verified end-to-end on the cluster.

## The three problems & fixes

### 1. Node-level DNS
The `nfs:` volume type mounts at the **kubelet/node** level. Talos nodes resolve via the host resolver (`169.254.x`), **not** cluster CoreDNS — so `nfs-server.storage.svc.cluster.local` was unresolvable (`mount.nfs: Failed to resolve server`). Confirmed neither `*.svc.cluster.local` nor `*.internal.tnwks.us` resolve from the node, but nodes **can** reach ClusterIPs directly.

**Fix:** Service gets a fixed `clusterIP: 10.43.255.254` (top of SERVICE_CIDR, clear of the dynamic range); nginx and the runner reference it **by IP**.

### 2. Static export
The `nfs-provisioner` image's default entrypoint only exports a metadata-only `PSEUDO` root — it's built for *dynamic per-PVC* provisioning, not a static dir.

**Fix:** bypass the entrypoint and run `ganesha.nfsd` directly against a ConfigMap `ganesha.conf` that statically exports `/export` over NFSv4, RW, via the **VFS FSAL**. (pid file → `/tmp`, since the image's default path isn't writable.)

### 3. VFS FSAL backing filesystem
Ganesha's VFS FSAL needs `name_to_handle_at`. The `local-path` SC stores data on `/mnt/e` — a **DrvFs/9p** mount that doesn't support file handles (`vfs_lookup_path: Could not get handle for path /export, Operation not supported (95)`).

**Fix:** back the PVC with **`local-path-ext4`** (real ext4 VHDX) and move the nfs-server node pin **worker-2 → worker-1** (where that SC lives). This is the same DrvFs wall that already puts postgres on `local-path-ext4` (see `STORAGE_CLASS_DATABASE` in cluster-settings).

The storageClass + node pin are patched in the WSL-specific `nfs-server-ks.yaml` (frigate pattern); the shared manifest stays generic.

## Verified live

- nfs-server pod **Running** on worker-1; PVC **Bound** on `local-path-ext4`.
- ganesha exports `/export` with **no FSAL error**.
- A pod on **worker-2** mounts `10.43.255.254:/export` over NFSv4.1 (cross-node, via ClusterIP) and **reads + writes** files.

## Note on consumers

In-pod mountPaths are unchanged (`/usr/share/nginx/html`, `/sites`); only the NFS `server` (now an IP) and `path` (`/export`) changed. The `tnwks-sites` build workflow is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
