### PR TITLE
fix(sites): probe /healthz so nginx survives an empty docroot

### DIFF
--- a/kubernetes/apps/production/sites/app/configmap.yaml
+++ b/kubernetes/apps/production/sites/app/configmap.yaml
@@ -13,6 +13,14 @@ data:
         root /usr/share/nginx/html;
         index index.html;
 
+        # Liveness/readiness endpoint — always 200, independent of whether any
+        # project has been published yet (an empty docroot otherwise 403s on /).
+        location = /healthz {
+            access_log off;
+            add_header Content-Type text/plain;
+            return 200 "ok\n";
+        }
+
         # Root SPA fallback (a site published directly at /).
         location / {
             try_files $uri $uri/ /index.html;

--- a/kubernetes/apps/production/sites/app/deployment.yaml
+++ b/kubernetes/apps/production/sites/app/deployment.yaml
@@ -36,13 +36,13 @@ spec:
               readOnly: true
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
             initialDelaySeconds: 10
             periodSeconds: 30
           readinessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10


### PR DESCRIPTION
## What

Fixes an nginx restart loop: probe a dedicated `/healthz` endpoint instead of `/`.

## Why

nginx mounts the NFS share correctly, but the share has no `index.html` until a project is published. The liveness/readiness probes hit `/` and got **403 "directory index forbidden"** on the empty docroot → probe failed → pod restart-looped (`403` in the logs, `RESTARTS` climbing).

## Fix

Add `location = /healthz { return 200; }` (always 200, independent of docroot contents) and point both probes at it. Serving behaviour is unchanged — `/` still SPA-falls-back to `index.html` once content exists.

## Verified live

The whole platform is now confirmed working end-to-end on the cluster:
- **nfs-server** (ganesha/VFS on local-path-ext4, worker-1) serving `/export`.
- **nginx** mounts `10.43.255.254:/export`, runs clean (no restart with this fix).
- **runner** `sites-builder-…-runner` is **2/2 Running** (runner + dind sidecar, `/sites` NFS mounted); ARC connected to `iT3E/tnwks-sites` via the GitHub App and holds 1 idle runner (minRunners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
