### PR TITLE
feat: gate sites /*/private/* behind oauth2-proxy

### DIFF
--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -288,13 +288,23 @@ resource "aws_cognito_user_pool_client" "oauth2_proxy" {
 
   generate_secret = true
 
-  # Second callback_url is the post-enrollment landing for the
+  # oauth2-proxy fronts two entry hosts off one app client:
+  #   - oauth2.internal.tnwks.us → internal apps (Grafana et al.)
+  #   - oauth2.tnwks.us          → the public sites platform (sites.tnwks.us)
+  # oauth2-proxy derives the callback per entry host (no static redirect_url in
+  # its helmrelease), so BOTH callbacks must be registered here or Cognito
+  # rejects the public flow with "redirect_uri mismatch".
+  # The grafana.internal.tnwks.us entry is the post-enrollment landing for the
   # /passkeys/add managed-login flow.
   callback_urls = [
     "https://oauth2.internal.tnwks.us/oauth2/callback",
+    "https://oauth2.tnwks.us/oauth2/callback",
     "https://grafana.internal.tnwks.us/",
   ]
-  logout_urls = ["https://oauth2.internal.tnwks.us/oauth2/sign_out"]
+  logout_urls = [
+    "https://oauth2.internal.tnwks.us/oauth2/sign_out",
+    "https://oauth2.tnwks.us/oauth2/sign_out",
+  ]
 
   allowed_oauth_flows                  = ["code"]
   allowed_oauth_flows_user_pool_client = true

--- a/kubernetes/apps/auth/oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/oauth2-proxy/app/helmrelease.yaml
@@ -34,7 +34,13 @@ spec:
       configFile: |-
         provider = "oidc"
         oidc_issuer_url = "${COGNITO_OIDC_ISSUER_URL}"
-        redirect_url = "https://oauth2.${INTERNAL_DOMAIN}/oauth2/callback"
+        # No static redirect_url. This single oauth2-proxy now fronts two entry
+        # hosts — oauth2.internal.tnwks.us (internal apps like Grafana) and the
+        # public oauth2.tnwks.us (the sites platform). With reverse_proxy=true
+        # below, oauth2-proxy derives the callback per-request from the
+        # X-Forwarded-* headers ingress-nginx sets, so each host gets its own
+        # /oauth2/callback. Both callbacks are registered on the Cognito app
+        # client (see infrastructure/terraform/.../cognito.tf).
         upstreams = ["static://200"]
         email_domains = ["*"]
         scope = "openid email profile"
@@ -51,8 +57,18 @@ spec:
         skip_jwt_bearer_tokens = false
         session_store_type = "cookie"
         reverse_proxy = true
-        whitelist_domains = [".${INTERNAL_DOMAIN}"]
-        cookie_domains = [".${INTERNAL_DOMAIN}"]
+        # Broadened from .${INTERNAL_DOMAIN} to .${SECRET_DOMAIN} (the apex,
+        # tnwks.us). .${INTERNAL_DOMAIN} is a strict subset, so internal apps
+        # (Grafana et al.) keep working unchanged — but the sites platform lives
+        # at sites.${SECRET_DOMAIN}, which is a sibling of internal.* not a child,
+        # so the old cookie domain would never reach it (auth loop). The apex
+        # covers both subtrees with one session cookie.
+        #   - whitelist_domains: lets oauth2-proxy honor rd= redirects back to
+        #     any *.tnwks.us host (else it rejects them as open-redirects).
+        #   - cookie_domains: sets the session cookie on .tnwks.us so it's sent
+        #     to both internal.tnwks.us and sites.tnwks.us.
+        whitelist_domains = [".${SECRET_DOMAIN}"]
+        cookie_domains = [".${SECRET_DOMAIN}"]
         cookie_expire = "720h"
         cookie_refresh = "23h"
         cookie_secure = true

--- a/kubernetes/apps/auth/oauth2-proxy/app/ingress-public.yaml
+++ b/kubernetes/apps/auth/oauth2-proxy/app/ingress-public.yaml
@@ -1,0 +1,55 @@
+---
+# Public oauth2-proxy entry point — oauth2.${SECRET_DOMAIN} (e.g. oauth2.tnwks.us).
+#
+# The chart's built-in ingress (helmrelease.yaml `ingress:` block) stays on the
+# nginx-internal class at oauth2.${INTERNAL_DOMAIN} for internal apps like
+# Grafana. This second, public ingress (class `nginx`, reached via the
+# cloudflared tunnel) lets a visitor on the public sites platform
+# (sites.${SECRET_DOMAIN}) complete the sign-in flow — its auth-signin redirect
+# points here.
+#
+# Both hosts front the SAME oauth2-proxy Service. oauth2-proxy has no static
+# redirect_url (see helmrelease.yaml), so it derives /oauth2/callback per entry
+# host from the X-Forwarded-* headers — each host gets its own callback, and
+# both are registered on the Cognito app client
+# (infrastructure/terraform/aws/accounts/prod/cognito.tf).
+#
+# The shared session cookie is scoped to .${SECRET_DOMAIN} (cookie_domains in
+# the helmrelease), so a session minted via oauth2.${SECRET_DOMAIN} is also
+# valid for sites.${SECRET_DOMAIN} and every internal.${SECRET_DOMAIN} host.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: oauth2-proxy-public
+  namespace: auth
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
+    # Cognito JWTs are large; oauth2-proxy splits the session cookie into
+    # chunks whose combined Set-Cookie headers overflow nginx's default 4k
+    # proxy buffer on /oauth2/callback (surfaces as 502). Match the internal
+    # ingress's buffer bump.
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
+spec:
+  ingressClassName: nginx
+  # No secretName — the public ingress-nginx default-ssl-certificate is the
+  # wildcard *.${SECRET_DOMAIN} cert, which covers oauth2.${SECRET_DOMAIN}.
+  tls:
+    - hosts:
+        - "oauth2.${SECRET_DOMAIN}"
+  rules:
+    - host: "oauth2.${SECRET_DOMAIN}"
+      http:
+        paths:
+          # Scope the PUBLIC surface to /oauth2/* only — the sites sign-in flow
+          # needs /oauth2/{start,callback,sign_out}. The auth-subrequest itself
+          # (/oauth2/auth) is hit cluster-internally via the Service, not through
+          # this ingress, so it does not need to be public. Backending `/` here
+          # would needlessly expose every oauth2-proxy route to the internet.
+          - path: /oauth2
+            pathType: Prefix
+            backend:
+              service:
+                name: oauth2-proxy
+                port:
+                  name: http

--- a/kubernetes/apps/auth/oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/auth/oauth2-proxy/app/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 namespace: auth
 resources:
   - ./helmrelease.yaml
+  - ./ingress-public.yaml

--- a/kubernetes/apps/production/sites/app/configmap.yaml
+++ b/kubernetes/apps/production/sites/app/configmap.yaml
@@ -26,6 +26,17 @@ data:
             try_files $uri $uri/ /index.html;
         }
 
+        # Private data files: /<project>/private/* holds JSON (e.g. budget.json)
+        # gated by oauth2-proxy at the ingress. These are DATA, not SPA routes —
+        # they must NOT fall back to index.html (that would hand an authed client
+        # an HTML page instead of a 404 for a missing/renamed file). Must precede
+        # the per-project SPA block below: nginx evaluates regex locations in
+        # order, first match wins. Auth itself is enforced one layer up by the
+        # ingress; this block only governs static-file resolution.
+        location ~ ^/[^/]+/private(/|$) {
+            try_files $uri =404;
+        }
+
         # Per-project SPA fallback: requests under /<project>/ that don't map
         # to a real file fall back to that project's index.html so Angular
         # client-side routing works at sites.tnwks.us/<project>/.

--- a/kubernetes/apps/production/sites/app/ingress.yaml
+++ b/kubernetes/apps/production/sites/app/ingress.yaml
@@ -1,4 +1,11 @@
 ---
+# PUBLIC ingress — everything under sites.${SECRET_DOMAIN}/ that is NOT a
+# /<project>/private/ path. Deliberately has NO oauth2-proxy auth annotations:
+# the trip pages, assets, and SPA routes are all world-readable.
+#
+# nginx-ingress routes by longest-matching path, so the more specific
+# /<project>/private prefixes on the `sites-private` ingress below win for those
+# requests; this ingress catches everything else.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -19,6 +26,58 @@ spec:
         paths:
           - path: /
             pathType: Prefix
+            backend:
+              service:
+                name: sites
+                port:
+                  name: http
+---
+# PRIVATE ingress — gates /<project>/private/* behind oauth2-proxy via the
+# nginx auth-subrequest. Reusable for any project on the platform: the path
+# pattern is the generic /<project>/private prefix, not one project's slug.
+#
+# A separate Ingress (rather than auth annotations on the public one) keeps the
+# auth surface surgically scoped to the private prefix — the public ingress
+# stays annotation-free so a misconfigured auth-url can never take the whole
+# site down. Both target the same `sites` Service.
+#
+# No external-dns target annotation here: the public `sites` ingress above
+# already owns the sites.${SECRET_DOMAIN} DNS record. A second claim on the same
+# host would make external-dns fight itself over ownership.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sites-private
+  namespace: production
+  annotations:
+    # Auth subrequest: nginx asks oauth2-proxy (cluster-internal Service) whether
+    # the request carries a valid session. 202 → allow; 401 → run auth-signin.
+    nginx.ingress.kubernetes.io/auth-url: "http://oauth2-proxy.auth.svc.cluster.local/oauth2/auth"
+    # On 401, redirect the browser to the PUBLIC oauth2 host so an external
+    # visitor on sites.${SECRET_DOMAIN} can actually reach the sign-in flow.
+    # rd= returns them to the page they were on after Cognito completes.
+    nginx.ingress.kubernetes.io/auth-signin: "https://oauth2.${SECRET_DOMAIN}/oauth2/start?rd=$scheme://$host$escaped_request_uri"
+    # Cognito sessions span multiple cookies; the auth-subrequest header chunk
+    # overflows nginx's default 4k buffer. Match what Grafana/oauth2-proxy use.
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
+    # The path below is a regex (any project slug + /private/...). No rewrite —
+    # the original URI passes through to nginx, which serves the file from NFS.
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - "sites.${SECRET_DOMAIN}"
+  rules:
+    - host: "sites.${SECRET_DOMAIN}"
+      http:
+        paths:
+          # Matches /<project>/private and everything beneath it, for ANY single
+          # project slug. use-regex (above) makes ingress-nginx treat this as a
+          # regex; ImplementationSpecific defers path semantics to the controller.
+          - path: /[^/]+/private(/.*)?$
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: sites


### PR DESCRIPTION
## What

Adds an authentication gate for **private content on the sites platform**, reusable by any project via the generic `/<project>/private/*` path. Companion to **tnwks-sites** `feat/private-budget-auth`, which moves the trip budget behind it.

## Changes

### `sites` app
- **New `sites-private` Ingress** — oauth2-proxy auth-subrequest (`auth-url` + `auth-signin`) scoped to the regex `/[^/]+/private(/.*)?$` (`use-regex: true`). Kept as a **separate** Ingress so the public `sites` Ingress stays annotation-free — a misconfigured `auth-url` can't take the whole site down. No `external-dns` target (the public Ingress already owns the `sites.${SECRET_DOMAIN}` record).
- **nginx configmap** — a `/<project>/private` location doing `try_files $uri =404` (no SPA fallback; these are data files, not routes), ordered before the per-project SPA fallback.

### oauth2-proxy
- **Broaden `cookie_domains`/`whitelist_domains`** from `.${INTERNAL_DOMAIN}` to the apex `.${SECRET_DOMAIN}`. The sites platform lives at `sites.${SECRET_DOMAIN}`, a **sibling** of `internal.*`, not a child — the old cookie domain would never reach it (auth loop). The apex is a strict superset, so existing internal apps (Grafana et al.) keep working unchanged.
- **Drop the static `redirect_url`** so the single proxy derives `/oauth2/callback` per entry host (`reverse_proxy` already enabled).
- **New public `oauth2.${SECRET_DOMAIN}` Ingress** (class `nginx`, via the cloudflared tunnel), scoped to `/oauth2`, so public sites visitors can complete sign-in. The internal host stays on `nginx-internal`.

### `cognito.tf`
- Register the `oauth2.tnwks.us` callback + `sign_out` URLs on the oauth2-proxy app client alongside the existing internal ones (Cognito rejects unregistered `redirect_uri`s).

## Security review

Reviewed for auth-bypass. Verified against ingress-nginx controller v1.12 source + nginx docs:
- **Encoded-slash bypass (`private%2Fbudget.json`): not exploitable.** nginx normalizes/decodes `%2F` *before* regex matching, and `use-regex` forces all locations on the host into regex form sorted by descending length — so the private regex wins and auth fires.
- **Common-case gating: sound.** `/<project>/private/budget.json` matches the auth-gated location.
- Aligned the backend nginx private location to `^/[^/]+/private(/|$)` so a bare `/<project>/private` (no trailing slash) returns 404 rather than the SPA index.
- Scoped the public oauth2 Ingress to `/oauth2` (not `/`) so only the sign-in endpoints are internet-exposed; the auth-subrequest reaches oauth2-proxy cluster-internally via the Service.

### Tradeoff (intentional)
Broadening the cookie to `.${SECRET_DOMAIN}` widens the session cookie's scope from internal-only to all `*.tnwks.us`. This is the minimal change that makes `sites.tnwks.us` auth work and is documented inline in the helmrelease.

## Deploy order

This PR is the gate; merge it (Flux reconcile) before/with the tnwks-sites PR. The Cognito `callback_urls` change must apply for the public sign-in flow to succeed.

## Validation checklist (post-deploy)
- [ ] `curl -i https://sites.tnwks.us/van-trip-colorado-2026/private/budget.json` (no session) → 302 to sign-in / 401
- [ ] After Cognito auth → budget.json returns 200
- [ ] Public trip page still loads fully unauthenticated, no budget section
- [ ] Grafana (internal) sign-in still works (cookie superset)
