### PR TITLE
feat(selfhosted): deploy Plausible Analytics CE v3.2.1

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/cluster.yaml
@@ -23,13 +23,14 @@ spec:
     enablePodMonitor: ${SERVICE_MONITOR_ENABLED}
   # Annotations on the generated `postgres-app` Secret tell stakater/reflector
   # to mirror it into namespaces that need the credentials (e.g. mealie in
-  # production/, litellm in ai/). The reflected Secret keeps the same name + keys.
+  # production/, litellm in ai/, plausible in selfhosted/). The reflected Secret
+  # keeps the same name + keys.
   inheritedMetadata:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "production,ai"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "production,ai,selfhosted"
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "production,ai"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "production,ai,selfhosted"
   bootstrap:
     initdb:
       database: app

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/database-plausible.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/database-plausible.yaml
@@ -1,0 +1,20 @@
+---
+# Declarative database creation for Plausible Analytics CE.
+#
+# Sibling of database.yaml (litellm). Same rationale: the Database CRD
+# reconciles continuously, so adding a database to an already-running cluster
+# is pure GitOps. `ensure: present` is idempotent.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: plausible
+  namespace: databases
+spec:
+  cluster:
+    name: postgres
+  name: plausible
+  owner: app
+  ensure: present
+  # Keep the database if this resource is ever removed — never let a manifest
+  # deletion drop application data.
+  databaseReclaimPolicy: retain

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/kustomization.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: databases
 resources:
   - ./cluster.yaml
   - ./database.yaml
+  - ./database-plausible.yaml
 # PrometheusRule lives in cluster-prometheusrules/ behind its own
 # Kustomization that depends on kube-prometheus-stack so the CRD
 # exists before apply.

--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -4,5 +4,6 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./obsidian-couchdb/ks.yaml
+  - ./plausible/ks.yaml
   # - ./external-dns/ks.yaml
 

--- a/kubernetes/apps/selfhosted/plausible/app/clickhouse/clickhouse-config.xml
+++ b/kubernetes/apps/selfhosted/plausible/app/clickhouse/clickhouse-config.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+  ClickHouse server overrides for Plausible's sidecar event store.
+
+  Dropped into /etc/clickhouse-server/config.d/ so it MERGES over the image's
+  default config.xml rather than replacing it (data paths, users, the
+  plausible_events_db creation handled by Plausible's `db createdb`, etc. all
+  stay at their defaults). This file only tightens two things:
+
+    * Network — bind to localhost only. ClickHouse is a same-pod sidecar
+      reached over 127.0.0.1:8123; nothing outside the pod should talk to it.
+    * Logging — cut the noise. ClickHouse's default info-level server log and
+      per-query system tables are pure overhead for an embedded analytics
+      store and otherwise fill the PVC.
+-->
+<clickhouse>
+  <!-- Same-pod sidecar: HTTP on 127.0.0.1:8123 only, no external listener. -->
+  <listen_host>127.0.0.1</listen_host>
+  <listen_host>::1</listen_host>
+
+  <!-- Quiet the server log; warning is enough to surface real problems. -->
+  <logger>
+    <level>warning</level>
+    <console>true</console>
+  </logger>
+
+  <!-- Disable the chatty internal telemetry tables that just grow the PVC. -->
+  <query_log remove="remove" />
+  <query_thread_log remove="remove" />
+  <metric_log remove="remove" />
+  <asynchronous_metric_log remove="remove" />
+  <trace_log remove="remove" />
+  <session_log remove="remove" />
+  <part_log remove="remove" />
+  <text_log remove="remove" />
+  <crash_log remove="remove" />
+</clickhouse>

--- a/kubernetes/apps/selfhosted/plausible/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/plausible/app/helmrelease.yaml
@@ -1,0 +1,134 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app plausible
+  namespace: selfhosted
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.7.3
+      interval: 30m
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  values:
+    controllers:
+      plausible:
+        type: statefulset
+        annotations:
+          reloader.stakater.com/auto: "true"
+        statefulset:
+          # ClickHouse event store needs durable storage. One claim, mounted
+          # only into the clickhouse container via advancedMounts.
+          volumeClaimTemplates:
+            - name: clickhouse-data
+              accessMode: ReadWriteOnce
+              size: 5Gi
+              storageClass: "${STORAGE_CLASS_DEFAULT}"
+              advancedMounts:
+                plausible:
+                  clickhouse:
+                    - path: /var/lib/clickhouse
+        containers:
+          app:
+            image:
+              repository: ghcr.io/plausible/community-edition
+              tag: v3.2.1
+            # Upstream compose entrypoint: create the Postgres + ClickHouse
+            # databases (incl. plausible_events_db), run migrations, then boot.
+            # `createdb`/`migrate` are idempotent, so this is safe on restart.
+            command:
+              - "sh"
+              - "-c"
+              - "/entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh run"
+            env:
+              - name: BASE_URL
+                value: "https://analytics.${SECRET_DOMAIN}"
+              - name: SECRET_KEY_BASE
+                valueFrom:
+                  secretKeyRef:
+                    name: plausible-secret
+                    key: SECRET_KEY_BASE
+              # CNPG app password, sourced from the reflected `postgres-app`
+              # secret (reflector mirrors it into the `selfhosted` namespace).
+              # Composed into DATABASE_URL via k8s env-var expansion so the
+              # password itself never lands in git.
+              - name: DATABASE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: postgres-app
+                    key: password
+              - name: DATABASE_URL
+                value: "postgres://app:$(DATABASE_PASSWORD)@postgres-rw.databases.svc.cluster.local:5432/plausible"
+              - name: CLICKHOUSE_DATABASE_URL
+                value: "http://localhost:8123/plausible_events_db"
+              - name: DISABLE_REGISTRATION
+                value: "invite_only"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: 8000
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+              # Migrations run before the web server binds the port; give them
+              # generous headroom (up to ~10m) before the pod is marked failed.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: 8000
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+          clickhouse:
+            image:
+              repository: clickhouse/clickhouse-server
+              tag: 24.3-alpine
+            # The clickhouse-server entrypoint starts as root and chowns
+            # /var/lib/clickhouse to the clickhouse user itself, so no fsGroup
+            # or init chown is needed (cf. the WSL emptyDir fsGroup caveat).
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+    service:
+      app:
+        controller: plausible
+        ports:
+          http:
+            port: 8000
+    persistence:
+      # ClickHouse server overrides (logging + localhost listener). Merged
+      # over the image defaults via the config.d drop-in directory; mounted
+      # only into the clickhouse container.
+      clickhouse-config:
+        type: configMap
+        name: plausible-clickhouse-config
+        advancedMounts:
+          plausible:
+            clickhouse:
+              - path: /etc/clickhouse-server/config.d/logging.xml
+                subPath: clickhouse-config.xml
+                readOnly: true

--- a/kubernetes/apps/selfhosted/plausible/app/ingress.yaml
+++ b/kubernetes/apps/selfhosted/plausible/app/ingress.yaml
@@ -1,0 +1,86 @@
+---
+# PUBLIC, UNAUTHENTICATED tracking ingress. The Plausible tracking script
+# (/js/script.js) and the event collection endpoint (/api/event) are hit by
+# every visitor's browser on sites we measure — they MUST be reachable without
+# a session. nginx routes by longest-matching path, so these specific prefixes
+# win over the catch-all `/` on the authenticated `plausible` ingress below.
+#
+# This ingress owns the analytics.${SECRET_DOMAIN} DNS record (external-dns
+# target); the dashboard ingress below deliberately omits the target so the two
+# don't fight over ownership of the same host.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: plausible-tracking
+  namespace: selfhosted
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
+spec:
+  ingressClassName: nginx
+  # No secretName — the ingress-nginx default-ssl-certificate is the
+  # wildcard *.${SECRET_DOMAIN} cert, which covers analytics.${SECRET_DOMAIN}.
+  tls:
+    - hosts:
+        - "analytics.${SECRET_DOMAIN}"
+  rules:
+    - host: "analytics.${SECRET_DOMAIN}"
+      http:
+        paths:
+          - path: /js
+            pathType: Prefix
+            backend:
+              service:
+                name: plausible
+                port:
+                  name: http
+          - path: /api/event
+            pathType: Exact
+            backend:
+              service:
+                name: plausible
+                port:
+                  name: http
+---
+# DASHBOARD ingress — everything that is NOT tracking traffic (the login,
+# stats UI, settings, invites). Gated behind oauth2-proxy via the nginx
+# auth-subrequest so only authenticated users reach the dashboard.
+#
+# A separate Ingress (rather than auth annotations on the tracking one above)
+# keeps the auth surface surgically scoped: a misconfigured auth-url can never
+# take down public tracking. Both target the same `plausible` Service.
+#
+# No external-dns target here: the tracking ingress above already owns the
+# analytics.${SECRET_DOMAIN} record. A second claim would make external-dns
+# fight itself over ownership.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: plausible
+  namespace: selfhosted
+  annotations:
+    # Auth subrequest: nginx asks oauth2-proxy (cluster-internal Service)
+    # whether the request carries a valid session. 202 → allow; 401 → signin.
+    nginx.ingress.kubernetes.io/auth-url: "http://oauth2-proxy.auth.svc.cluster.local/oauth2/auth"
+    # On 401, redirect the browser to the PUBLIC oauth2 host so an external
+    # visitor can reach the sign-in flow. rd= returns them to where they were.
+    nginx.ingress.kubernetes.io/auth-signin: "https://oauth2.${SECRET_DOMAIN}/oauth2/start?rd=$scheme://$host$escaped_request_uri"
+    # Cognito sessions span multiple cookies; the auth-subrequest header chunk
+    # overflows nginx's default 4k buffer. Match what Grafana/oauth2-proxy use.
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - "analytics.${SECRET_DOMAIN}"
+  rules:
+    - host: "analytics.${SECRET_DOMAIN}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: plausible
+                port:
+                  name: http

--- a/kubernetes/apps/selfhosted/plausible/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/plausible/app/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: selfhosted
+resources:
+  - secrets.sops.yaml
+  - helmrelease.yaml
+  - ingress.yaml
+commonLabels:
+  app.kubernetes.io/name: plausible
+  app.kubernetes.io/instance: plausible
+configMapGenerator:
+  - name: plausible-clickhouse-config
+    files:
+      - clickhouse/clickhouse-config.xml
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/selfhosted/plausible/app/secrets.sops.yaml
+++ b/kubernetes/apps/selfhosted/plausible/app/secrets.sops.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: plausible-secret
+    namespace: selfhosted
+type: Opaque
+stringData:
+    #ENC[AES256_GCM,data:WkyNEBbvBHvshDd51hVGCYyIoalryCdPgWz/jFCabcZn4+uQYAT4T7rbhjMu6xE38m12Vi7aEJ7d1TEL0YMXMRB0SpTc7CrySUs=,iv:jiGShNFk825OGMQpY8zuyJgqKIjsdpbvtPDxQLmaobI=,tag:UX4cqUYgkzOSWsZVG6gO8A==,type:comment]
+    #ENC[AES256_GCM,data:PeHzTKTnxSjLOmNm/yJcHW7/keyiTEPdAIKqk/zkN3FyIxk/kfbsXTRF3ZSn2evbErKo/0CbHz5mJ1YUAPEipZ6eAn3CBVQ=,iv:ngugp7X4ntD+kenWXUoSGL94eYpzkMLLJsHR0HvTLDw=,tag:UjuJoNDQyN1Cxf8PwpqK5w==,type:comment]
+    #ENC[AES256_GCM,data:BFA6WjkBeBYwTjGk0lURfcqcOK6a6e8KZNGFoILLCJIFkW7C0ZdQugVxREf7M5QomtlTV7r6t3HoLuro+a1ETESUjpswC9VS,iv:DeddtQlKkc874hK2WYst01VrZ88nlAuM3OVavSwjKEQ=,tag:DoxSl/kgk53Y95auisKvOg==,type:comment]
+    #ENC[AES256_GCM,data:8yq6d8qa/1fX4juFI/+uYxN9+L44bsMfBqZ1pw7XTduKv9o3c727ul/c44Nn+wrwXpLSarBvIw4=,iv:9uuGSnh2Wu0OGB1HO3ydAodoFs0M7P6RFjuYEBdBMh8=,tag:EgzOGvR/7W8M4l+KN1JhJA==,type:comment]
+    SECRET_KEY_BASE: ENC[AES256_GCM,data:i/43obs0iTdUaUK/2qfaEkROh9SecikPUlx2s71t7UD4DlDFvoBrTIcOqz35jDiK+siYmP1ApLWJsu7ACvA7oA==,iv:pT60hvHYdpUWm4hn7B0ujeAq+2qkO0FiOJW8Yqx/rR8=,tag:jKOLNK/HcuPjajkrBiDoGA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1mzxwncaj0364q8jxfj0y73ptt63czwxucf9lrnn28c7kwyr5wfdsj9gsk2
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBldVVEd3p6dzEzMTBZcEdn
+            TldsMGV5YXZqazdlMm4zK29aV0N3WXFNWVNjCkxxb0FLWXU4bEpmdVA4TTNzL1dS
+            QVRydmg2S3dHWEFBZGN2Rmk1TFNjN0UKLS0tIEoxbGxZODNzaGZsbXNYWHFLbDhB
+            UUNwVTlhZFhmbWE4TnpHSERGTmtiSkUKjMh8ry7V+RuxM80sJwTlHV+zIhOAAPBl
+            lrmEnTxWSpo5el69jv9cWx1EpZc8NEecYRqv5zQHcZy7mLdZpdaaVA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age12uckcdwv9p2s75ae3h20wgn70taatdzzl44n9x6vr8h9qurzkaqqkhphz7
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2clJZS3RpREdrazd4TGth
+            RmVIWTZVRHRoMk1zaVZPUCtydDhnb1JXQUZnCnJBeVdnMWhuRWZURmprcE1HWjBt
+            UURacEt0VVZBUUx1VXUzZDRmazFrWVkKLS0tIDNMMDhoVTZncnhIYUVUV2ZBdDBa
+            cTJsOG5oNFFVZzhvcmxQQUtqNzZ6emMKHHysEMnK2GVjGqUtGePTuePSV1LpQOhw
+            hmNXTjT2O8UWEn1pAifgz1Dk55ofIdqmXXDQ3Mv2BFYfF8TWfAYu6w==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hmmuna95ktwl9sf9j56wjjukyf22ukdyjd8c47nlf5fjgyeyk5rsmhtyjx
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWZ2hqbk9qVWZDeGFHd0V0
+            RjR4czgvMW1BMHlWTXBUcjdTMUdlV1hoSldnCm15dEo2UWxaWW0wRTNHWWZDaE5x
+            YVlFZ0gyTW5OVDhPTkpGZ0R5SWRKcHMKLS0tIGJrMHo3M1VlQldiTS9tNitZejds
+            cmxPdmxXRDB5YXBvNmFjL2ZYaGJjZWMKhvDFI20EHyZzpJwlT2GAJKGs9ho3i8oe
+            wsXB9lV9MKmkRpaqRnTCvsNiWZy0NJBWbsfLvlr7ad1K1jxK2X01Qw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-02T00:14:39Z"
+    mac: ENC[AES256_GCM,data:+0vSu6Aa/J3+hWHY3AQtHx3OOpOSj6x4jgO7uwC7i5ym5E5Z93GqHFw7tkSvf3wA423xEK5B9yiGDaPFghD7uXreJFjqahrQ/9w1xyPL4DVLQMkwxL5DXEyStn2vNDT1aqgKuGMSynHpos4xFGf91c897S4+qJov4qA8MpIT9+8=,iv:CwoJcMUxzOMiBVlbRp0ei4rvhJQ2OMTUGzyMelMHqtg=,tag:DS5L6b5OIpiuRUDkVs75pA==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.3

--- a/kubernetes/apps/selfhosted/plausible/ks.yaml
+++ b/kubernetes/apps/selfhosted/plausible/ks.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: plausible
+  namespace: flux-system
+spec:
+  # Gate on:
+  #   * cloudnative-pg-cluster — owns the `plausible` Database CRD and the
+  #     `postgres-app` Secret that reflector mirrors into selfhosted/.
+  #   * oauth2-proxy — the dashboard ingress uses it for auth-subrequest.
+  dependsOn:
+    - name: cloudnative-pg-cluster
+    - name: oauth2-proxy
+  path: ./kubernetes/apps/selfhosted/plausible/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false # no flux ks dependents
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## What

Deploys [Plausible Analytics CE](https://github.com/plausible/community-edition) **v3.2.1** in the `selfhosted` namespace, behind oauth2-proxy, with a dedicated CNPG database and a co-located ClickHouse event store.

## Changes

**databases/cloudnative-pg**
- New `plausible` Database via the CNPG Database CRD (`database-plausible.yaml`), wired into the cluster kustomization. Reconciles onto the running cluster — no first-boot dependency.
- Reflector allow/auto namespaces extended to include `selfhosted` so the generated `postgres-app` secret mirrors there (same pattern litellm uses in `ai/`).

**selfhosted/plausible**
- `ks.yaml` — Flux Kustomization, `dependsOn` `cloudnative-pg-cluster` (DB + reflected secret) and `oauth2-proxy` (dashboard auth backend).
- `helmrelease.yaml` — bjw-s `app-template` 3.7.3 StatefulSet:
  - `plausible` web container `ghcr.io/plausible/community-edition:v3.2.1`, port 8000. Entrypoint runs `db createdb && db migrate && run` (idempotent), which creates `plausible_events_db` in ClickHouse and the Postgres schema.
  - `clickhouse` sidecar `clickhouse/clickhouse-server:24.3-alpine` on a 5Gi `${STORAGE_CLASS_DEFAULT}` PVC mounted at `/var/lib/clickhouse`.
  - `DATABASE_URL` composed from the reflected CNPG password via k8s env-var expansion — **no DB password in git**. Only `SECRET_KEY_BASE` lives in the SOPS secret.
- `ingress.yaml` — two ingresses on `analytics.${SECRET_DOMAIN}`:
  - `plausible-tracking` (PUBLIC, no auth): `/js` (Prefix) + `/api/event` (Exact); owns the external-dns record.
  - `plausible` (oauth2-proxy gated): `/` catch-all for the dashboard, with the auth-subrequest annotations matching the `sites-private` pattern.
- ClickHouse `config.d` drop-in binds the sidecar to localhost and disables the noisy default telemetry logging.

## Validation (non-mutating)

- `kubectl kustomize` builds clean for the cnpg cluster dir, the plausible app overlay, and the selfhosted Flux Kustomizations.
- `sops -d` confirms the secret decrypts.

## ⚠️ SOPS / KMS note

This environment couldn't assume `role/iam-role-sops`, so `secrets.sops.yaml` is encrypted with the **three age recipients only** (no AWS KMS recipient). The cluster `sops-age` key is one of those recipients, so **Flux decrypts it fine** — but humans/CI relying on KMS won't be able to decrypt until it's re-keyed with `sops updatekeys` from a host with AWS access.