### PR TITLE
fix(plausible): correct VCT advancedMounts shape

### DIFF
--- a/kubernetes/apps/selfhosted/plausible/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/plausible/app/helmrelease.yaml
@@ -31,9 +31,8 @@ spec:
               size: 5Gi
               storageClass: "${STORAGE_CLASS_DEFAULT}"
               advancedMounts:
-                plausible:
-                  clickhouse:
-                    - path: /var/lib/clickhouse
+                clickhouse:
+                  - path: /var/lib/clickhouse
         containers:
           app:
             image:


### PR DESCRIPTION
Follow-up to #1297. The initial install failed app-template schema validation:

```
at '/controllers/plausible/statefulset/volumeClaimTemplates/0/advancedMounts/plausible': got object, want array
```

Within a `volumeClaimTemplates` entry the controller is already implied, so `advancedMounts` is keyed by **container name directly** (`container → [mounts]`), unlike the top-level `persistence` block which is `controller → container → [mounts]`. Removed the redundant `plausible:` controller level.

`kubectl kustomize` builds clean; verifying the HelmRelease installs after merge.