### PR TITLE
feat(ai): add playwright-mcp browser automation server

### DIFF
--- a/kubernetes/apps/ai/playwright-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/playwright-mcp/app/helmrelease.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app playwright-mcp
+spec:
+  chart:
+    spec:
+      chart: app-template
+      version: 3.7.3
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  interval: 30m
+  maxHistory: 2
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      playwright-mcp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/acuvity/mcp-server-playwright
+              tag: 0.0.56
+            env:
+              # Run in SSE transport mode for network-accessible MCP
+              - name: TRANSPORT
+                value: sse
+              - name: PORT
+                value: "8000"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8000
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8000
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 12
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false # Playwright needs writable dirs
+              runAsNonRoot: true
+              runAsUser: 1000
+              runAsGroup: 1000
+    service:
+      app:
+        controller: playwright-mcp
+        ports:
+          http:
+            port: 8000
+    ingress:
+      app:
+        className: nginx-internal
+        hosts:
+          - host: &host "playwright-mcp.${INTERNAL_DOMAIN}"
+            paths:
+              - path: /
+                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http
+    persistence:
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          playwright-mcp:
+            app:
+              - path: /tmp

--- a/kubernetes/apps/ai/playwright-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/ai/playwright-mcp/app/kustomization.yaml
@@ -1,7 +1,6 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: ai
 resources:
-  - ./namespace.yaml
-  - ./litellm/ks.yaml
-  - ./playwright-mcp/ks.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/playwright-mcp/ks.yaml
+++ b/kubernetes/apps/ai/playwright-mcp/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: playwright-mcp
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/ai/playwright-mcp/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Deploy acuvity/mcp-server-playwright as an SSE-accessible MCP server in the ai namespace.

**What:**
- Headless Chromium browser automation exposed as MCP (SSE transport)
- Enables agents to interact with Cloudflare-protected sites, handle logins, scrape authenticated content

**Details:**
- Image: `acuvity/mcp-server-playwright:0.0.56`
- Chart: bjw-s app-template 3.7.3
- Ingress: `playwright-mcp.internal.tnwks.us`
- Port: 8000 (SSE)
- Resources: 100m/512Mi request, 2Gi limit
- Non-root, emptyDir for /tmp

**Namespace:** ai (alongside litellm)