### PR TITLE
fix(ai): correct playwright-mcp health probe port

### DIFF
--- a/kubernetes/apps/ai/playwright-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/playwright-mcp/app/helmrelease.yaml
@@ -46,8 +46,8 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /health
-                    port: 8000
+                    path: /
+                    port: 8080
                   initialDelaySeconds: 10
                   periodSeconds: 30
                   timeoutSeconds: 5
@@ -58,8 +58,8 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /health
-                    port: 8000
+                    path: /
+                    port: 8080
                   initialDelaySeconds: 5
                   periodSeconds: 5
                   timeoutSeconds: 5


### PR DESCRIPTION
Health/readiness probes were hitting :8000/health which returns 404. The actual health endpoint is on :8080/ (minibridge metrics manager).