### PR TITLE
fix(ai): add writable emptyDir for playwright chromium data

### DIFF
--- a/kubernetes/apps/ai/playwright-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/playwright-mcp/app/helmrelease.yaml
@@ -100,3 +100,9 @@ spec:
           playwright-mcp:
             app:
               - path: /tmp
+      playwright-data:
+        type: emptyDir
+        advancedMounts:
+          playwright-mcp:
+            app:
+              - path: /app/ms-playwright/mcp-chromium


### PR DESCRIPTION
Playwright needs /app/ms-playwright/mcp-chromium writable for browser profile data. Without it: EACCES on navigate.