### PR TITLE
feat(auth): back oauth2-proxy sessions with Valkey instead of cookies

### DIFF
--- a/kubernetes/apps/auth/oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/oauth2-proxy/app/helmrelease.yaml
@@ -55,7 +55,21 @@ spec:
         set_xauthrequest = true
         set_authorization_header = false
         skip_jwt_bearer_tokens = false
-        session_store_type = "cookie"
+        # Server-side (Valkey) session store, not cookie. Cognito's
+        # access+id+refresh tokens exceed the 4kB cookie limit, so the cookie
+        # store split the session into _oauth2_proxy_{0,1,..} chunks. The 23h
+        # silent refresh runs inside nginx's auth_request subrequest, whose
+        # Set-Cookie headers nginx discards — so the browser kept stale chunks,
+        # they failed HMAC ("cookie signature not valid"), and users were
+        # bounced to re-login at the 24h access-token boundary despite the
+        # 30-day refresh token. With Valkey the browser holds only a small,
+        # stable ticket cookie (unchanged across refresh — the tokens live
+        # server-side under the same key), so the subrequest never needs to
+        # rewrite a cookie and the session rides the refresh token to 30 days.
+        # See kubernetes/apps/cache/valkey.
+        session_store_type = "redis"
+        redis_connection_url = "redis://valkey.cache.svc.cluster.local:6379"
+        redis_password = "${VALKEY_PASSWORD}"
         reverse_proxy = true
         # Broadened from .${INTERNAL_DOMAIN} to .${SECRET_DOMAIN} (the apex,
         # tnwks.us). .${INTERNAL_DOMAIN} is a strict subset, so internal apps

--- a/kubernetes/apps/auth/oauth2-proxy/ks.yaml
+++ b/kubernetes/apps/auth/oauth2-proxy/ks.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   dependsOn:
     - name: ingress-nginx-internal
+    # Session store must exist before oauth2-proxy starts, else it crashloops
+    # on a redis dial error. valkey's ks.yaml has a HelmRelease healthCheck.
+    - name: valkey
   path: ./kubernetes/apps/auth/oauth2-proxy/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/cache/kustomization.yaml
+++ b/kubernetes/apps/cache/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./valkey/ks.yaml

--- a/kubernetes/apps/cache/namespace.yaml
+++ b/kubernetes/apps/cache/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cache
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/cache/valkey/app/helmrelease.yaml
+++ b/kubernetes/apps/cache/valkey/app/helmrelease.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: valkey
+  namespace: cache
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.7.3
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        runAsNonRoot: true
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      valkey:
+        # Single-node session store for oauth2-proxy. Memory-only by design:
+        # sessions are a cache, not a source of truth (Cognito is). A restart
+        # forces every active user to re-authenticate once — the same cost as
+        # today's cookie-store behaviour — so HA/persistence isn't warranted.
+        # See kubernetes/apps/auth/oauth2-proxy for the consumer.
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/valkey/valkey
+              tag: 9.1.0-alpine@sha256:a35428eba9043cc0b79dbe54100f0c92784f2de00ad09b01182bfb1c5c83d1bd
+            # Keep the image entrypoint (docker-entrypoint.sh) and drive config
+            # via args. ${VALKEY_PASSWORD} is substituted by Flux from
+            # cluster-secrets (same mechanism oauth2-proxy uses for its
+            # client secret).
+            #   --save "" / --appendonly no : disable RDB+AOF, fully in-memory.
+            #   --maxmemory-policy noeviction: never silently drop a live
+            #     session under memory pressure; oauth2-proxy sets a TTL on
+            #     every key so they expire on their own.
+            args:
+              - valkey-server
+              - --requirepass
+              - ${VALKEY_PASSWORD}
+              - --save
+              - ""
+              - --appendonly
+              - "no"
+              - --maxmemory
+              - 128mb
+              - --maxmemory-policy
+              - noeviction
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 192Mi
+    service:
+      app:
+        controller: valkey
+        ports:
+          valkey:
+            port: 6379
+    persistence:
+      # valkey-server's working dir is /data; with persistence disabled it
+      # writes nothing here, but readOnlyRootFilesystem still needs a writable
+      # path for it to chdir into. emptyDir keeps the pod stateless.
+      data:
+        type: emptyDir
+        globalMounts:
+          - path: /data

--- a/kubernetes/apps/cache/valkey/app/kustomization.yaml
+++ b/kubernetes/apps/cache/valkey/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cache
+resources:
+  - ./helmrelease.yaml
+commonLabels:
+  app.kubernetes.io/name: valkey
+  app.kubernetes.io/instance: valkey

--- a/kubernetes/apps/cache/valkey/ks.yaml
+++ b/kubernetes/apps/cache/valkey/ks.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: valkey
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/cache/valkey/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  # oauth2-proxy gates its own reconcile on this HelmRelease being healthy
+  # (see kubernetes/apps/auth/oauth2-proxy/ks.yaml), so surface health here.
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: valkey
+      namespace: cache
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -9,6 +9,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./auth
+  - ./cache
   - ./cert-manager
   - ./databases
   - ./default

--- a/kubernetes/clusters/ms-01/cluster-secrets.sops.yaml
+++ b/kubernetes/clusters/ms-01/cluster-secrets.sops.yaml
@@ -4,23 +4,24 @@ metadata:
     name: cluster-secrets
     namespace: flux-system
 stringData:
-    MAUBOT_ADMIN_PASSWORD: ENC[AES256_GCM,data:UlRNadAy/NX4PU4ffp3L6Ku7qwT4Pc8dL6+PhA==,iv:8sSD7DLBKJMAQnLtIfPTVFNERJBgt/6NOqJ9V4mKKwQ=,tag:Kvhpdjiim4lGJ/q2VEDJhQ==,type:str]
-    SECRET_DOMAIN: ENC[AES256_GCM,data:6UViELRkMc4=,iv:G+ZSUyRDp3hP4IQkLGUMS5U4qmL5hZqCJr71o/ZUYeM=,tag:qIf2QpM9XihzjLspXwaHmQ==,type:str]
-    SECRET_PREFIX: ENC[AES256_GCM,data:ZYBdWs6/j1fH,iv:17cxNJMMRWw/zBaJh/d/V6wxqECz0f1K2gbjwLzgnNs=,tag:HD+gQDwrTWY+LXAkrGlDLg==,type:str]
-    SECRET_ACME_EMAIL: ENC[AES256_GCM,data:MoO8ZUpq6opfROnzOe+cTw==,iv:Fpk0auCFpTfUKUFI8He9mpPE1xzvOkziq/EV0iAwfm0=,tag:nVj2ZH+80o1M4wN210Z7/A==,type:str]
-    SECRET_CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:dsa7DtGfRzf1lmlEFLBHeF1D+3sUd/zhZtNlLfQ0XbVu49FF,iv:RRZCLfXJJAZEunRsXWFI+SjuzUEofmyvT8bh87/r7rQ=,tag:fxabTJZUVOX7NqVKBOt8UA==,type:str]
-    POSTGRES_USER: ENC[AES256_GCM,data:aIfUugA/,iv:BZNcWtUB+1DeMxeDqDd7a/+wAySUrfcbrAxwHxj/gfM=,tag:L9QoiLtlpfBk3/jc0pVeVQ==,type:str]
-    POSTGRES_PASSWORD: ENC[AES256_GCM,data:rVzBbYxiMJWH8B5oNSaqP2QvP+q36riN,iv:HpEnG2NjvnSKfjCuLHmnnhdN5IbU/A0yObD6b5FTDr4=,tag:LgRgEpxWYZP+J45Fd56pqQ==,type:str]
-    POSTGRES_SERVER: ENC[AES256_GCM,data:UPCFf+2mx91OGtSw,iv:p3ghKT/RKumdP0nzwpGRiwDVt1paHTqkHIkO7x+VQmM=,tag:2TSU0kCQflIC5RjVrpV2aQ==,type:str]
-    SMTP_USER: ENC[AES256_GCM,data:qwc0NbPG+oaOwit6cRybyqxrClM=,iv:hKy1qjXqETsRy5FNjstrPGRn2ihFNDvcNVabOpMdFjI=,tag:rmNWU25Ps11hP0WHk+ySDA==,type:str]
-    SMTP_PASSWORD: ENC[AES256_GCM,data:85JtyiLRmGAeO03pJAEMSiTRgMYCF9txnUHrlvCMbcnk9cdpXf3nI5sk7EU=,iv:0mDoVk6QRI7zup2SS5vhriV28bMaa71WHE2+PdV9WQM=,tag:K7vb1lmtW/K28jrEcujPTQ==,type:str]
-    TIMEZONE: ENC[AES256_GCM,data:JiB9l+FvwJY4ZrolJLm/Svdh5Q==,iv:O2KLNlxeIZjjWxMAQuFBp4W03amK65ILyb6gGfqs+pY=,tag:mE7OdQOTdB0iyrxl0fToGg==,type:str]
+    VALKEY_PASSWORD: ENC[AES256_GCM,data:ch+IbsRK4ftQPihZqFHK/HN/U957zy/D9AqtkiqVISgujQX7hKN5lmDJmm3vMgzi,iv:brt1wEE5d/WlDCy7d0wscxhgU8nLe1esUw6hwnamSIM=,tag:nfqe71WfknS8Uj3mtav0Ww==,type:str]
+    MAUBOT_ADMIN_PASSWORD: ENC[AES256_GCM,data:y06I6a1rp5+13RiIduacB1NvhV6AvfEWnwKeSw==,iv:2aLiLIm+RZ9f0fcd7DO8AudjcxeoGuQUM1urn+i7neQ=,tag:8z285EEk0Hl94dsG7kx4bA==,type:str]
+    SECRET_DOMAIN: ENC[AES256_GCM,data:+NKGrE0xAxU=,iv:V6AhWDC0vXdxOwUmoPWOa+2aedwCUMF2xuaTfctfvJw=,tag:IWHt/yPadWQ9frnPp0f1yg==,type:str]
+    SECRET_PREFIX: ENC[AES256_GCM,data:4wEOpgJ+kRrq,iv:IdPyq3ktEiVYbvSt27Yb5iKSWDm8PVuY1lZqdbUSHQs=,tag:hfgUrAAeCxLcbTfbZcU2Ww==,type:str]
+    SECRET_ACME_EMAIL: ENC[AES256_GCM,data:gD3doRAvgI0VHPkKY+SqQQ==,iv:0bgGEQIErA40jdvH8WNnitEzvUSNFWUEBxMLWmzPV4E=,tag:y34GgQxVz95C4wUFFmbmuw==,type:str]
+    SECRET_CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:Efpk51mBlVy37DEZzBIT39150c/27D4vi5g7BCkeRtjlA8g0,iv:HujdCWWCvGndcK/3DxOkVEwRuE8HFzMP3EC0QYLz3Mo=,tag:8xP/bVJMLB4yr0i3jm5i2g==,type:str]
+    POSTGRES_USER: ENC[AES256_GCM,data:/HRq0CM5,iv:SKhZ88tnD9UllcBN3BVD4XVUJ+IzTLX/7rmHmXQcHXc=,tag:QVhPfYZD9dU4V/7FUgrN8g==,type:str]
+    POSTGRES_PASSWORD: ENC[AES256_GCM,data:ejR/9ImO3WrcZkbnMS4mH7b+qbwuHshy,iv:H+6tw/I/6aHglUoT4aZqzww3X3w6Naa2o0LpejPGEGk=,tag:pEEBw1EmEb7ohhv73kCQdg==,type:str]
+    POSTGRES_SERVER: ENC[AES256_GCM,data:kioPXyIe8+A7bfTD,iv:hELgB08UTcRI6ZxCbSjqy2FL/1URller6iwlfQIExns=,tag:6aNeEsVZ1CGXW3OCK41h5Q==,type:str]
+    SMTP_USER: ENC[AES256_GCM,data:MrzfPsEvkaVow+4tgC2gIY41opk=,iv:6U7maVywerzW0XarpHIL8JkA+Zpc4qiLg9u7hEspIhk=,tag:XMtQMQM3AhmUEb2uL8RucQ==,type:str]
+    SMTP_PASSWORD: ENC[AES256_GCM,data:3tuG2CzbKr9MMF+jVdYuJI7gAnQA1Mx+hGN16x0aixRRnz/a5U2sMsr/YBc=,iv:lQADgEe5+z9iQcLbWsmZYhN9R22jSAFb4EvthlbDH2s=,tag:l2PLs+eh98OfCOyk4uKwPw==,type:str]
+    TIMEZONE: ENC[AES256_GCM,data:QSHmwExxFSinKgSyj/KLJigWGg==,iv:3zbD3Tg2IJeygmVVNsulzQzjuupEr/HI9X0PL7eAt5M=,tag:Pf/evBTAWda71ND+uUf97Q==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-west-2:654654220436:key/mrk-74c4597ebffd41d38a852228e13d76cc
           role: arn:aws:iam::654654220436:role/iam-role-sops
-          created_at: "2026-05-24T15:56:08Z"
-          enc: AQICAHhNDAK0Is+rGNAlNYnav2FEvs37O7WQwrCmqkcTMDWNIQG2T6BR7acgATQETIL8M2mOAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMQO56Uc/RJt3Gc9R/AgEQgDulVprxcYz9M9E6K2NxOS1HTMRdE6AwEiOwZvyOneVhvqyjp16X1hU41C57beJWQGV7OitrkUt6/UU4Dw==
+          created_at: "2026-06-03T00:35:25Z"
+          enc: AQICAHhNDAK0Is+rGNAlNYnav2FEvs37O7WQwrCmqkcTMDWNIQFYRP2Fv9S7J3Gi3WDL6jKpAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM6ioC+Ncc69Egb+l/AgEQgDu0p6bYFzo1HIgTzi7td3dtb2x0bbDNi1LKogVkcbTz9AXtjcKEfF9hAqZwp/9fiVI2YrHSv3IlZnPhhg==
           aws_profile: ""
     gcp_kms: []
     azure_kv: []
@@ -29,32 +30,32 @@ sops:
         - recipient: age1mzxwncaj0364q8jxfj0y73ptt63czwxucf9lrnn28c7kwyr5wfdsj9gsk2
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZQ09lSXhsc3M5TVprWnM0
-            ZUhpRXVZTjcwdlgwUUx2SVRIdS9Vdks2OFdBCnpSblE4SlVybzlJZXd0SDI1aE5j
-            M3dDcGZoMmkxYVpDa05iTzhreSt4MHcKLS0tIDROTXdESVV3djdMNXlrNGhGSStV
-            RDZJSDNGZDJmZTJqei9BeTNxYUlPR0kKPvMXTxHjifeabkak18OI9PCjZEDfqoNm
-            8HiqStYMQNm8OVTDmDhgifvX8yr9mbRQP0BLmsU7IEHNsBAEuxcWzg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQL1hnY0FVdTI4UUFhZ29M
+            cEdNZkl1QjE4VkI4WFRNRGxodDZqY3BUZ0NJCnF1QTNkODRWbS9wbnFwdGpsKzF2
+            MEZnOE4rKzdaOWc5ZSt6RW1Rd2ljdFEKLS0tIEp6MTkyUUlFOStrSHlmQ3Bud3BX
+            bk82SGRtMkw5cEVvY2F2SmFBdTVLZmMKoDEJfF5a4TkQfr8l17mIyKfnRkTEL8Ub
+            4JAwQVkUzomybZV8pABLEXcd7sRQT8hXTFAI/sf7oVQ4dCT1N6tMJQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age12uckcdwv9p2s75ae3h20wgn70taatdzzl44n9x6vr8h9qurzkaqqkhphz7
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBySlJmN1BEaFVqOTlUdTNK
-            L211ZklNaTlLM29BdmtxbDYyMUdFUWUxWUhrClk4dVErYlVjYnd0SDZYYTBDUkds
-            V1ZpU2NvNGRicmtSOUV6QUk4Yk5sQncKLS0tIDZuTkhrc0JvRllobzFEUGNKYWo2
-            MWh1UDY2ZVk3NUptSGc2dWVaUTlEN2sKACwADzI/SqS488VtzVsIJtV+c2DnaERI
-            llY6y5Y/FvEq5kuwi0kvxjVVPpgSq52+r3o9hfWj4ftVLdaWSFDuMg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwYlljSmtKTWZPOW9tdkpU
+            YXQ0ejhScXJBN1VjVk9vUTdUQW91YXhuK0RBCjFRUzZUVGhWbDhpSjRZL3NPZ1lF
+            ZUhtTjgvUHovUWNsNmUwbXdjT1NIYUEKLS0tIGZQNHFsdWxIOWZZVDN3WGhHMlAy
+            VE9FNXdJaTZkdlIweHRadmRmSzUyZWsK+Nk6A7ssQ0iKToc8C46PM+F7vtH+s1vq
+            uKKKsgaZYzui5JlX/eEDNZnkQRrUbM76cMYtxndjOo8fbjXHl/0kpA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hmmuna95ktwl9sf9j56wjjukyf22ukdyjd8c47nlf5fjgyeyk5rsmhtyjx
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlUDBqU2gwMy9RNWdnSFJv
-            YVkydUZYTzZuMUJyYUZQajcwdmxYQ0ROQlFNCnNlU3hTWlJRbnppd2EyNUxsU3V1
-            UjhqR1dINWZsbHdGSGNJZjVGWER0YUEKLS0tIDdZdHFMUlhMWWFPYzdjNHRuaVhi
-            TjZvdS95WTlsZFgxdWZ0NnJoT25uSGMKN3H5fOo4wOpDgdFrVXz/A4e7MYIHW9d3
-            C67IxFSJYqiy4IP9FRWPHQ2eImBd5+VsWI9qqLRopyp2NJbe0JKKTw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJQjFyaHJyWjI1VFlNYSs5
+            WmRFTzBLOFpmZGpVejNXUVVnd09Db3hMRnpFCkhSa091aW5nR0V6aUxYSGF3L2Uy
+            OStaUzcrYWQ1ZndieS9lY0tHM0wwUjAKLS0tIENGSHZWaWR0bzgwcHc5M2pnUUpD
+            Tm1zU0lFampxdDBVTThGV2plRWtCdnMKUR51xMTGrPLkECyocgJyN9K8DG4oyCZX
+            +LUST/tlxH9Q5P1nxUGyVj/t8lc30xtj2PAOfVO1uIZpEmjK4/y5UQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-01-16T02:01:50Z"
-    mac: ENC[AES256_GCM,data:4RKl/5ZJ9YCjrwZRj/pvsRIE5rJ3rPDXT0+lPyo4lqYYcKJ4YT1qer8gw2Zjd2NBKONr/0iXN7gwHswFBa6gj80MDPNPjsqwyu42cNyJzoZyym27rW42wWi+1gq6m4vcJV/6lUWyceqRJwgHeoc/VZ0aO26IzUjXIdYkGv64tJg=,iv:tb7VN6/fbuQ72hHAvkeemtq0zXTQfl3jPIh58UA6TkA=,tag:1Fec752neZvcpbMxcw42Fw==,type:str]
+    lastmodified: "2026-06-03T00:35:26Z"
+    mac: ENC[AES256_GCM,data:45vuI66JM3kUZ7k2t2qI3p7+yxGpmSAXP/PEaxuJx6S8+sDjsA6DBcPi64guMCPz2WRvAVzSLIp0tszW0GVRi0zoYRNRHbHoRHMY/uU0TMRIFMs+9GhSdpsXWiT2u9yWEiLIh559t/x2KwZeME0dkbHwh3GqvbNLuz5X2G+UixQ=,iv:s9pumlTCzGDNyuXG0rrQ9bMIkw62YQH9A0oVXQrW6pQ=,tag:k5jbdeE/RYbFX7zbGe6KnQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
-    version: 3.8.1
+    version: 3.7.3

--- a/kubernetes/clusters/wsl/apps/kustomization.yaml
+++ b/kubernetes/clusters/wsl/apps/kustomization.yaml
@@ -26,6 +26,7 @@ resources:
   # Shared namespaces — used as-is
   - ../../../apps/ai
   - ../../../apps/auth
+  - ../../../apps/cache
   - ../../../apps/cert-manager
   - ../../../apps/databases
   - ../../../apps/default

--- a/kubernetes/clusters/wsl/cluster-secrets.sops.yaml
+++ b/kubernetes/clusters/wsl/cluster-secrets.sops.yaml
@@ -4,30 +4,31 @@ metadata:
     name: cluster-secrets
     namespace: flux-system
 stringData:
-    MAUBOT_ADMIN_PASSWORD: ENC[AES256_GCM,data:ct0bGKe9n2XrGhc4uGPF6/G/7tdMO7g38jhhtg==,iv:EbQ5YmE+APpJlhE7IjB9MscGLsvgQJwQ8rifyIA5YDA=,tag:NvITevo8u65DoSV6dkV7yA==,type:str]
-    SECRET_DOMAIN: ENC[AES256_GCM,data:EN+EoISJV4c=,iv:KbOVmA+FJTAkWp82CekhYd/wXD8A2RoXrjYE0D+jnrA=,tag:KG6snpUA/C/VRF0zRcm83w==,type:str]
-    SECRET_PREFIX: ENC[AES256_GCM,data:8xbNnjosoCTM,iv:CA+6V96NwPTIHUtuf1Stvmp7TxGJ62j5RJefA/xTTts=,tag:uDh6O6Y8llvmCrCYesRLDg==,type:str]
-    SECRET_ACME_EMAIL: ENC[AES256_GCM,data:U5XV2iIKBZTrAC7/4Yn/Cw==,iv:+YlEj6p+kztX940GgTi3Tnr1d0eTa8MZvpREG38j/rw=,tag:mS4bvwfmUNZ1Mv8/T10qug==,type:str]
-    SECRET_CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:kHUK/ThRNocJq5TTzdRqX5sdpAcYVyDiZA9eGCyz02GbDyp8,iv:tRCe+YxnAVGXcPUMW5IcHouBqI5C/LYF9197SlinGC4=,tag:wMaoVH8M2sQPi2huXqS2Ag==,type:str]
-    POSTGRES_USER: ENC[AES256_GCM,data:/X6B,iv:PnC4r2LkaR0km9YId4zwNQlFOfvI0C1DdCkfloMUNm8=,tag:Q2GSVPddmePJ/WsVZMNiZQ==,type:str]
-    POSTGRES_PASSWORD: ENC[AES256_GCM,data:0QD0ITekF8cjwBJmRMGpETLmqIQlDVU6ffPsXqlVrurzpZnmvNCFiUDYjQW+jD1C/m8gPMKEZY1slLqe4MP22g==,iv:xFQhZy6D/80iVpB4onFXS7zW48Dackif+xdvsmHKKgY=,tag:gTdODlrdkgM3Yms9iIrO7A==,type:str]
-    POSTGRES_SERVER: ENC[AES256_GCM,data:dGh4JK5Lrv0NnU1HOmnc08TalOq+P7Nx/1dUwI7nelBa1hMYhMWu,iv:prYjj2TghEzB7ATyiAeSItrD7tgOQbSz0ZfWi/EkGFw=,tag:lsPT1V556uYWSbKK7Z3vTQ==,type:str]
-    SMTP_USER: ENC[AES256_GCM,data:Mp1KpjKll2RuEirlgT00lEJmRrQ=,iv:AukJTLVS4S5McCCJFiCalpewmXIVjScuLxiTkrw18WU=,tag:Cufvci/DDAdDh3MePAeRww==,type:str]
-    SMTP_PASSWORD: ENC[AES256_GCM,data:nHntPT72eRsfvrenou069sNWo1HSIR9hhwmg+dBAxZofah+yA15Gk0uIUe8=,iv:sDIQzMbxsWaMyk1nRAFFgInk5XGihSOIjguFgcH1LDg=,tag:n9fu/a+WpmiQiC5/KGm9zg==,type:str]
-    TIMEZONE: ENC[AES256_GCM,data:/sajfowJMxgdSn9AhclNWbB3kg==,iv:QFB6MTvREyqBDO0tNKdKw2/+oCJKde1bCyCSpFAILs0=,tag:6Zlr963rfWFDDkGXWo2OIg==,type:str]
-    #ENC[AES256_GCM,data:jl3Qajq6fF89CWE4vIZ/xCaM3Q5h36o=,iv:uCEDuyRhBZzdpRYYoPEECDvDrHDIWk3PXH6IvkiZkDA=,tag:lbuXIiSodnsauK9WLFD3jA==,type:comment]
-    COGNITO_REGION: ENC[AES256_GCM,data:M+1DPaLzt8M6,iv:2o5bOkFlod1BUL3InbSqWOCOkc55HjR/KKULUNx36f8=,tag:3Ik1ImSP11KgveseKwaWHQ==,type:str]
-    COGNITO_USER_POOL_ID: ENC[AES256_GCM,data:N/VW9/pLVgV77SrPk0WsPflTtg==,iv:pylkgmG4bEMhwPjDETxVCiT8Laq4BfSY3UnEh9fsOfI=,tag:aycPWeF98vRIghisDAMWeQ==,type:str]
-    COGNITO_OIDC_ISSUER_URL: ENC[AES256_GCM,data:KTFNmSQnabu4PCd547QsjiPcbmU/tAclTteioWdVy/Mi1ChKa8tMiaQy9i4W8PKIjP/NyTh/wLtgDxKRilbU,iv:Cc2S+QK6ya2T5btPMZcYKFSeXg8VY0sPLzrd3RDfNuA=,tag:QRa+0kB8YAR2kcDINs54SA==,type:str]
-    OAUTH2_PROXY_CLIENT_ID: ENC[AES256_GCM,data:eWzE26fTwybotZSDer5Bpf2Ix3jb5HNFhw==,iv:TvDISMU1OPSCSNIadUXtFLG0voScuCfnBO9XQr5e4t8=,tag:9FUqjh5SCY8QxmLI8MNHWA==,type:str]
-    OAUTH2_PROXY_CLIENT_SECRET: ENC[AES256_GCM,data:c3dx4IuXA77yhU2plla4mvvoVeGyR3BCvx7WzgwM9iZtLjCOEHp8sqU4V7y7fwR0jfG1,iv:0CUjX/CLK+poCtccoh/dbGaCdgf0mNk2WRAb8+KKA+s=,tag:ri55gapEmDgvtPd7UhIuRg==,type:str]
-    OAUTH2_PROXY_COOKIE_SECRET: ENC[AES256_GCM,data:aNpszQWcf0faovolEhG0Co5N4dQYd0njuhOig5imrRA=,iv:j+EqCHvaI4lpaBpSrHwOeu1bzNfrwnrkaSKzRy17L8w=,tag:h52zDWcDqjz1wWqffK0/+A==,type:str]
+    VALKEY_PASSWORD: ENC[AES256_GCM,data:n2oWd0/GE7/91SZADdRJTMwKETgVaaUtgCBryzVTMVYu9iAcy+PqglxnWGziwVIC,iv:zvHcOXRyqvKDw7v72tOUef72jY5rdReNVkM6AvoVciw=,tag:gk5DgGTYaB9ucpa+prPCLg==,type:str]
+    MAUBOT_ADMIN_PASSWORD: ENC[AES256_GCM,data:CwIDlcmnaw4vZRhaBSC3pCbdx/EXR/t7TaJxnQ==,iv:GUv+zxh62o0oF6SKJC5wjX88BINF/4HYzuXfplFWiGM=,tag:3er1zYngnOlGCTeV7HL1Bg==,type:str]
+    SECRET_DOMAIN: ENC[AES256_GCM,data:zvQhJ1hwsZU=,iv:wHuOR4Jp3j/0KqtemXedgb5uuP9bNwmFD3597PZ6csE=,tag:7Wbcog4OeYSr4aTGpo8xcA==,type:str]
+    SECRET_PREFIX: ENC[AES256_GCM,data:ZmI2j8EYWaKO,iv:yWCkFoQ6drLNfLCDhE5Yp/tD9ZkXfma0f86QaWEWVp4=,tag:RAH+JQmrBzeCThTSfTyaLQ==,type:str]
+    SECRET_ACME_EMAIL: ENC[AES256_GCM,data:jwIQ6Va8aQXTrlq+bvKx/g==,iv:YpqcTc96KmgadSZfOrlXnsz+7iqSendi3Z7H1Z0Y19o=,tag:3P/WrOy1/xFApIe0X21TTA==,type:str]
+    SECRET_CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:wGJ5ZH0Yu+OCxw6j1qWlf3ZEKik7JNUxcznRSHvIIPzNIp9d,iv:3ljd6GbYOW0c9Ob39wxAHBB5LtP+SUvpBRrtNwM8CtA=,tag:7Kapj0NNXCveIbWUyMbA1Q==,type:str]
+    POSTGRES_USER: ENC[AES256_GCM,data:w+wp,iv:rzK4ndStvsgdTzrWtC8ogkRQdf2EtRaHnM2NDdiZQXM=,tag:MbPqkmv5Q/DSNCDk4xuEsw==,type:str]
+    POSTGRES_PASSWORD: ENC[AES256_GCM,data:Wvk0q9PVOcf8rqeuqALMKqGUm9J1Ljzi2J2hPERA1OoI7DcaK57qPVAUx//esWCt7qK9fzRAoo7RMogSIGahgA==,iv:TIJmih2Nh8qd1VtJrrp0Sl20NQ2wIXcArAgK5T3KCKA=,tag:FM865uDMkZENQyvOz5PMzQ==,type:str]
+    POSTGRES_SERVER: ENC[AES256_GCM,data:KaD1zrQQJp2T4dPc1C5JFsH5eZlz19bML7UdO1FioNmhviN/fj0c,iv:Ocjh+KvzR2ZEwyS8wtUJezMEMjutUXMTwYVvhHKcb30=,tag:QEAE7kwh5z41HwyG7/S6ag==,type:str]
+    SMTP_USER: ENC[AES256_GCM,data:QOqtfivRGeuNAKP7J8AMLfklOVM=,iv:DSjJV4yOMdstYSP8GFpXNdaayagu8OgA4c5NotwroSA=,tag:U2ftFGzD2Sq9GxynYz7bPg==,type:str]
+    SMTP_PASSWORD: ENC[AES256_GCM,data:9/EUM58B5SQ0vk1bKTOZmVPyjvXuhUoewM2UpMVWUB6+SUpXD76GCrOvcWQ=,iv:7iC3UIEWFLpSeTd2Qt4G04Ik0BsH/vRmN1YvOQoICUw=,tag:i/UDlpN5z/hc67uBJNAbXw==,type:str]
+    TIMEZONE: ENC[AES256_GCM,data:371R2CoIXejxqwUYylaJ0PZemA==,iv:CnJPar1/wNaiv6htTzwl4BTiV8G9O4J7v2NP9w4ZYrE=,tag:cOoom1oV8Yas3hDemOfpsQ==,type:str]
+    #ENC[AES256_GCM,data:qAvZ/UgDQhtF/iAca8jvlXga94lS/q8=,iv:XILDKhdxC18B4yuV5k+yeh9NLOPksGhY06x3Fj992lk=,tag:Eho65pWqQHBBGRHZirCZnA==,type:comment]
+    COGNITO_REGION: ENC[AES256_GCM,data:hnvT6RXkZEYf,iv:nVxtti4yt5uhB4u3DBpIB4Qb4qx9STc8ZOKHE97GVgs=,tag:8HchwpJc3TXlJQV7TijPTA==,type:str]
+    COGNITO_USER_POOL_ID: ENC[AES256_GCM,data:tkbHcWhvH/roy//lsYwZ9IEcjQ==,iv:kmXkGklGqGd/1rA6n0kktnpTB1rmaNo9t1UXZWMbGnk=,tag:s/P9lMaUSQf7VUiVfeeZcA==,type:str]
+    COGNITO_OIDC_ISSUER_URL: ENC[AES256_GCM,data:CYFw5aXvecKRZZWmgs86wp/gHCXt7yQjo4D2Tu9TPWnkMW54O4fXvOlk/DSgXjD0xBftfZuMoJgzLJ1CAnYk,iv:wvOJuIlYSxzJo6WixHRpCTwFSHBrEAirRIReon5FWes=,tag:1k/k4A6DJhFSngq81Xgfxw==,type:str]
+    OAUTH2_PROXY_CLIENT_ID: ENC[AES256_GCM,data:+mIdKjTU+D1oCE183j5emNkCDwHXwFwXDA==,iv:MeATjHLLHYREsN1BjPKvr5OcLs4nVPlMxjDv88wL2q4=,tag:tTVLRp1mOlyksYhG+CDkQQ==,type:str]
+    OAUTH2_PROXY_CLIENT_SECRET: ENC[AES256_GCM,data:kFWO09cF6JlKJk7elWgjaGUX5dj/ys6h8MOIzXHUC8SaT6RlF7q330goJ9utVTC16IVV,iv:g9XcsRr3BYUzuviVrCVmLXl3t+k7WXuv9nD9eoUFgzI=,tag:TbtPB/2aduAfQyAYEopXBQ==,type:str]
+    OAUTH2_PROXY_COOKIE_SECRET: ENC[AES256_GCM,data:0gosq46C9BhEj/KLM2dGxjQMR307HjpJRHT7Q076eXE=,iv:LK0vfw6rYnTCZoCgUWjOBWZyUiluvG+F3pTZKCasE/0=,tag:BhjKN4WDJWPnF+dH9c7eCA==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-west-2:654654220436:key/mrk-74c4597ebffd41d38a852228e13d76cc
           role: arn:aws:iam::654654220436:role/iam-role-sops
-          created_at: "2026-05-26T15:29:32Z"
-          enc: AQICAHhNDAK0Is+rGNAlNYnav2FEvs37O7WQwrCmqkcTMDWNIQGDo4hWVRTpAmvZ7FhP+WplAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMC8bwCXVU8vfghWYlAgEQgDvBWWMnHo8m5/JRCMHsadKXeef7XsP++cI+omIY2wdQGqUPZ/pRQdz0cKG7xohNEQ16Y/YXcWvSVUwXOg==
+          created_at: "2026-06-03T00:35:25Z"
+          enc: AQICAHhNDAK0Is+rGNAlNYnav2FEvs37O7WQwrCmqkcTMDWNIQFgx4AH87AMWSZlkdBKDItvAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMonjtrxLnqkXu2p2/AgEQgDvZH4xg9SDX6l7YP9DSWWeIjMUyZEmK32BFfo5PPpXgYqZQe+8GIeELdZlKlwSFRE5SCld65Lkg685Prw==
           aws_profile: ""
     gcp_kms: []
     azure_kv: []
@@ -36,32 +37,32 @@ sops:
         - recipient: age1mzxwncaj0364q8jxfj0y73ptt63czwxucf9lrnn28c7kwyr5wfdsj9gsk2
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyN2JEbW5nRTQzZGdvelky
-            NHNJc3NibTQ1WW1nVHJlQVEyclh5a3ZLWWdVCm02M3RRSHBjTXVXQ1dLT09rWG1E
-            UEw0UGwyUTd3NG9RMEVNdm9CcmxlQkUKLS0tIFo0ZE14QVJHdjJ4emdTUldQSmVJ
-            Y0RRSWhhTHVVM0F0Y1RzdW53NDJXUFUKamUN4dB8Ps3a1XWCTn9MuTvh0U8VabIZ
-            vLBrNXPcQ0eocy+94BhRN4lax37ikfsDTrljCVQZJtaIhF/uQrlQbg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjaGY3cUJiMjZRR2l6MXpt
+            eFRJelJpcUlNMURkSjVvd205MkdpVnlvOHdFClEwSEE2STRSY1Q0alBjbUtpUC9O
+            ZkxqRmN6TzIzbGsxN0NNTEtucENkQzQKLS0tIEhIV2wzelp0cTFZcHF4N3J6TkhY
+            MEdQVklCeWpQOTZQdWl4bUN2T0ZMeHMKDca4QU6VrD1TpxSZ2x3l25M+ohihpF2p
+            i3quzs5ip9KRjRcibEBZJpLYqz5WN8rKS1fMI615d1SKX+kh17EfQw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age12uckcdwv9p2s75ae3h20wgn70taatdzzl44n9x6vr8h9qurzkaqqkhphz7
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBueXdzTzc3VGs1SUVHQUI1
-            NXNGb0hGWWVJbHV1eTB3a2E4WnZzUktzcm4wClRFVyttTUNBWHZrckU4eGZUYkRU
-            aFk5Q0ZuZ25JbnB0cG94V3lBNW1HRFEKLS0tIFBBVmdIWjFxUko4UDdJTnJHNTRx
-            NU50cVBnT04zSkFlMGNWT0FRWWNnWnMKBcXFPWTh/U7TdGYkJ5SMRShLz9JktSlJ
-            pOcxYYREsb2H1KJn+UNSC7yPwfaUq8GUQ4SXvRMyyIOPYXyjWmJcrA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSdG51Mmx6RlZRQlllQVRj
+            WFE4cWZkSDlQVHVpSVhFV0ViSFU0R1luUWhJCkczRFZNeW0yaE8yTGlsd2h5M3Qv
+            MytncGRYSTBMTzlvVWZBNEVPcUhiWncKLS0tIHRpZnBNRWNwZ1ZpRm02MHQzblM4
+            M0JJTmxSTHRFNHladkFLcnRaMzU5bUUKgPbOxlaw3omvzHEnXShrNzSjkHgE67K2
+            NcVlu1jCGD9Tc2KiTkN2vl9gXUFRixiSxJHkxtlKcb7m/DOohgc0Og==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hmmuna95ktwl9sf9j56wjjukyf22ukdyjd8c47nlf5fjgyeyk5rsmhtyjx
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYTUJYemJ3Y2loU25XTVVm
-            SlY3U0VqaDhtTDMxdDdoNkc4WWRTcGhtVUZzCkgxY1RWZmZ1bktYZUVFZlllMVNL
-            bk5oU0dnK2t4U0JDYjdFVk52N0ZOVzQKLS0tIFBDdEFqTmgvVlNqZjBGSzk0SlFj
-            anpGNVNVUnlFd25NM0p1K1hyQ0tVUHMKWcNZhAcocdX+/RDQtjCccPd7z061mF3c
-            Z+8nJPQwQOWdaBeFd+8ZaZ54CM4HrzV6Cmy0VNGsezEpF8w+YCjmTg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyamNaWUJMdE1DK1R0dzFv
+            bHhiNHI4R3hLYkxwM1h1azVhU0xaYlpvRHpzCmdyT0J3cVRXRTJGczBINXBhNTBO
+            SzVJNVNHRW1uQ1NndjZ6dWgrNFBBNkkKLS0tIGI1T3dwMGY4My9lVXljTHp0RzlS
+            NXdMem1oVUdSd2xoTFZ6QWlzQWUzS2cKpUcu9vYdmZYv34QEjux7q1afBxcFDCPO
+            8tKoNWOR9uJ/p0Xlvcd01bbLRhcebHeVJ4v17yYae/iL94w6UwBFlA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-30T14:32:08Z"
-    mac: ENC[AES256_GCM,data:P0SZisJiqtlADaca5CDxEikFE5rlYI1lkqe90M5BZrtUkRQpCFrexnKZtszyzFzqgTgCEnDeuAC0LdjqNOzGLSt0k7/UFo+EzSPDwh1lqd8YIdCmITHmCyBnNkK/2bQdZjkcEuzGbqfPA3j/xUnD8+R3EUDXEeC6WcXNi/HgEks=,iv:z55UD9NkHULd5YZIWVGc7v8Px5qMvtxf6avSuXaPbI8=,tag:DM+fvbAsROjSEHKPX7P9GA==,type:str]
+    lastmodified: "2026-06-03T00:35:25Z"
+    mac: ENC[AES256_GCM,data:uVV84Oh2YnJAemP1reVSuu2F9BC5wYBmHPmBwDAGBeImrvtFIxnpYtUyWjkiZpSSGXKiLHblyvmLjlCRE0EGJC4rqyAueKIRlIc8BmilusZhjdpLzBsQJoNRSIOh8mkofKNZHV9FKurq3G2Ay+zH7NBU7Y67jRULlCGSt3sW+Ec=,iv:gs/jZdIydU7iT8nbEG1Xf0XOPl6TGrNkOxeJ+hlWtr4=,tag:1jDNIUjJcWMiTpmweiP+VQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.7.3


### PR DESCRIPTION
## Problem

Users get bounced to re-login ~every 24h on `sites.tnwks.us`, Grafana, and other oauth2-proxy-fronted apps — despite the Cognito refresh token being valid for **30 days**.

**Root cause:** oauth2-proxy used the **cookie** session store. Cognito's access+id+refresh tokens exceed the 4kB browser cookie limit, so the session was split into `_oauth2_proxy_{0,1,..}` chunks. The 23h silent refresh (`cookie_refresh = "23h"`) runs *inside* the nginx `auth_request` subrequest — and nginx **discards `Set-Cookie` headers from auth subrequests**. So the refreshed (re-chunked) cookie never reached the browser, the stale chunks failed HMAC validation (`cookie signature not valid, removing session` in the logs), and the session aged out at the 24h access-token boundary.

This is structural to the cookie-store + auth-subrequest combo, not a misconfiguration — AWS's own ALB auth solves the same large-Cognito-token problem by holding the refresh token server-side.

## Fix

Switch `session_store_type` to `redis`, backed by a new single-node **Valkey** in a `cache` namespace.

With a server-side store, the browser holds only a small **ticket** cookie whose value stays **byte-stable across a refresh** (oauth2-proxy reuses the existing ticket; only the server-side record is updated). The auth subrequest never needs to rewrite a cookie, so the session now rides the refresh token to the full 30 days.

## Design choices

- **Valkey, not Redis** — BSD-licensed, AWS-aligned, drop-in. (Redis Inc.'s 2024 relicense.)
- **Single-node + memory-only** — sessions are a cache, not a source of truth (Cognito is). A restart forces one re-login, the same cost as today's behaviour, so HA/persistence isn't warranted. (HA Sentinel was considered but the only turnkey chart is Bitnami's, whose images lost clean version tags in the Aug-2025 catalog change — not worth the supply-chain wart for this workload.)
- **Official `valkey/valkey` image, digest-pinned** via the bjw-s `app-template` chart, matching repo convention.
- `${VALKEY_PASSWORD}` added to both clusters' `cluster-secrets.sops.yaml`; consumed by both the Valkey HR (`--requirepass`) and oauth2-proxy (`redis_password`) via Flux substitution.
- oauth2-proxy gains `dependsOn: valkey` so it won't reconcile before the store is healthy.

## Validation (non-mutating, per AGENTS.md)

- `kustomize build` clean for both `wsl` and `ms-01` (77 / 82 docs)
- Valkey + oauth2-proxy HelmReleases pass `kubectl apply --dry-run=server` against the live CRDs
- `VALKEY_PASSWORD` decrypts via the age path in both secrets; all pre-existing keys intact
- app-template renders probes as `tcpSocket:6379` (correct for a password-protected Valkey — an exec PING would fail `NOAUTH`)

Shared `apps/auth` + new `apps/cache` reach **both** clusters; both are single-node here (no per-cluster sizing needed).
