### PR TITLE
feat(production): add packing-api for the van trip site

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/cluster/database-vantrip.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/database-vantrip.yaml
@@ -1,0 +1,22 @@
+---
+# Declarative database creation for the Van Trip packing-api (production ns).
+#
+# Sibling of database.yaml (litellm) / database-plausible.yaml. The Database
+# CRD reconciles continuously, so adding a database to an already-running
+# cluster is pure GitOps. `ensure: present` is idempotent. The packing-api
+# (production namespace) connects via the reflected `postgres-app` secret —
+# owner `app` matches that credential.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: vantrip
+  namespace: databases
+spec:
+  cluster:
+    name: postgres
+  name: vantrip
+  owner: app
+  ensure: present
+  # Keep the database if this resource is ever removed — never let a manifest
+  # deletion drop the packing list.
+  databaseReclaimPolicy: retain

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/kustomization.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./cluster.yaml
   - ./database.yaml
   - ./database-plausible.yaml
+  - ./database-vantrip.yaml
 # PrometheusRule lives in cluster-prometheusrules/ behind its own
 # Kustomization that depends on kube-prometheus-stack so the CRD
 # exists before apply.

--- a/kubernetes/apps/production/packing-api/app/deployment.yaml
+++ b/kubernetes/apps/production/packing-api/app/deployment.yaml
@@ -1,0 +1,82 @@
+---
+# packing-api — the write-backend for the editable, multi-user packing list on
+# the Van Trip page of the sites platform. The site itself is static (nginx off
+# NFS); this is the one stateful piece, so it gets its own tiny service +
+# Postgres-backed store.
+#
+# Source + image build: github.com/iT3E/tnwks-packing-api (pushes
+# ghcr.io/it3e/tnwks-packing-api:main on every merge).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: packing-api
+  namespace: production
+  labels:
+    app.kubernetes.io/name: packing-api
+  annotations:
+    # Roll the pod when the reflected postgres-app secret rotates.
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: packing-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: packing-api
+    spec:
+      containers:
+        - name: packing-api
+          # :main is the rolling tag CI pushes from the repo's main branch.
+          # imagePullPolicy Always so a re-pushed :main is actually picked up
+          # on pod restart (the tag is mutable).
+          image: ghcr.io/it3e/tnwks-packing-api:main
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            # DB connection. Username/password come from the CNPG-generated
+            # `postgres-app` secret, reflected into the production namespace
+            # (see the cnpg Cluster's inheritedMetadata). Same keys mealie uses.
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-app
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-app
+                  key: password
+            - name: POSTGRES_SERVER
+              value: "postgres-rw.databases.svc.cluster.local"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_DB
+              value: "vantrip"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 64Mi

--- a/kubernetes/apps/production/packing-api/app/ingress.yaml
+++ b/kubernetes/apps/production/packing-api/app/ingress.yaml
@@ -1,0 +1,53 @@
+---
+# packing-api ingress — gates the packing list's write API behind the SAME
+# oauth2-proxy auth-subrequest that protects /<project>/private/* on the sites
+# platform. A public visitor gets bounced to Cognito sign-in (the frontend
+# treats that as "not authenticated" and never shows the packing UI), exactly
+# like the private budget.json.
+#
+# Path: sites.${SECRET_DOMAIN}/van-trip-colorado-2026/api/...  ->  service /...
+# The rewrite strips the project+/api prefix so the Go service sees bare
+# /items, /items/{id}, /healthz.
+#
+# This is a separate Ingress from the `sites` and `sites-private` ones (which
+# live in the sites app). Keeping it here co-locates it with the service it
+# fronts, and longest-prefix routing in ingress-nginx means this more-specific
+# /van-trip-colorado-2026/api path wins over the public `/` sites ingress.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: packing-api
+  namespace: production
+  annotations:
+    # --- oauth2-proxy auth-subrequest (copied from sites-private) ---
+    nginx.ingress.kubernetes.io/auth-url: "http://oauth2-proxy.auth.svc.cluster.local/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://oauth2.${SECRET_DOMAIN}/oauth2/start?rd=$scheme://$host$escaped_request_uri"
+    # oauth2-proxy returns the authenticated identity on the auth subrequest;
+    # pass it through to the upstream so the service can stamp updated_by.
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Email,X-Auth-Request-User"
+    # Cognito sessions span multiple cookies; the subrequest header chunk
+    # overflows nginx's default 4k buffer. Match sites-private / oauth2-proxy.
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
+    # --- prefix rewrite ---
+    # Capture everything after /van-trip-colorado-2026/api and hand it to the
+    # service as /$1 (so /van-trip-colorado-2026/api/items -> /items, and the
+    # bare /van-trip-colorado-2026/api -> /).
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - "sites.${SECRET_DOMAIN}"
+  rules:
+    - host: "sites.${SECRET_DOMAIN}"
+      http:
+        paths:
+          - path: /van-trip-colorado-2026/api(?:/(.*))?$
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: packing-api
+                port:
+                  name: http

--- a/kubernetes/apps/production/packing-api/app/kustomization.yaml
+++ b/kubernetes/apps/production/packing-api/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: production
+resources:
+  - ./deployment.yaml
+  - ./service.yaml
+  - ./ingress.yaml

--- a/kubernetes/apps/production/packing-api/app/service.yaml
+++ b/kubernetes/apps/production/packing-api/app/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: packing-api
+  namespace: production
+  labels:
+    app.kubernetes.io/name: packing-api
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: packing-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP

--- a/kubernetes/apps/production/packing-api/ks.yaml
+++ b/kubernetes/apps/production/packing-api/ks.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: packing-api
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/production/packing-api/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false # no flux ks dependents
+  # Gate on the postgres cluster so the vantrip database + reflected
+  # postgres-app secret exist before the pod starts.
+  dependsOn:
+    - name: cloudnative-pg-cluster
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/clusters/wsl/apps/production/kustomization.yaml
+++ b/kubernetes/clusters/wsl/apps/production/kustomization.yaml
@@ -22,6 +22,10 @@ resources:
   # off the shared NFS export (nfs-server lives in the storage namespace, wired
   # in the WSL apps overlay one level up).
   - ../../../../apps/production/sites/ks.yaml
+  # packing-api: write-backend for the editable packing list on the Van Trip
+  # site. Gated by the same oauth2-proxy that protects /<project>/private/*,
+  # persists to the cnpg `vantrip` database. WSL-only, same as sites.
+  - ../../../../apps/production/packing-api/ks.yaml
   # frigate: WSL-specific Flux Kustomization with a patch to replace the
   # NFD coral nodeSelector with a hostname pin to homelab-wsl-worker-2.
   - ./frigate-ks.yaml


### PR DESCRIPTION
## What

Adds **packing-api**, the write-backend for the editable, multi-user packing
list on the Van Trip page (`sites.tnwks.us/van-trip-colorado-2026/`). The trip
site is otherwise static (nginx off NFS); the packing list is its one piece of
shared, mutable state, so it needs a server + store.

Source/image: [iT3E/tnwks-packing-api](https://github.com/iT3E/tnwks-packing-api) → `ghcr.io/it3e/tnwks-packing-api:main`.

## Changes

- **Deployment + Service** (`production` ns): the Go image, DB creds from the
  reflected `postgres-app` secret, connects to the new `vantrip` database.
  Read-only rootfs, drops all caps, 16Mi/64Mi.
- **Ingress**: gates `/van-trip-colorado-2026/api/*` behind the **same
  oauth2-proxy auth-subrequest** that protects `/<project>/private/*` (copied
  annotations + 16k proxy buffers), rewrites the project/api prefix off so the
  service sees bare `/items`, and forwards `X-Auth-Request-Email` for the
  `updated_by` stamp. Longest-prefix routing means it wins over the public `/`
  sites ingress. A public visitor gets bounced to Cognito → the frontend treats
  that as "not signed in" and never renders the packing UI, exactly like
  `budget.json`.
- **cnpg `Database` `vantrip`** (owner `app`, `retain`) alongside
  litellm/plausible — pure-GitOps DB creation on the running cluster.
- Wired into the **WSL production overlay** next to `sites` (WSL-only, same as
  sites).

## Validation (non-mutating)

- `kubectl kustomize kubernetes/apps/production/packing-api/app` renders
  Deployment/Service/Ingress correctly (auth annotations, rewrite-target, path
  regex all present).
- `kubectl kustomize --load-restrictor LoadRestrictionsNone kubernetes/clusters/wsl/apps`
  builds the full overlay (154 resources) with the `packing-api` Kustomization
  wired in.
- Service itself was integration-tested against a throwaway Postgres locally
  (seed, list, toggle, add, rename, soft-delete, no-reseed-on-restart).

## Prereq before this can pull

The GHCR package `tnwks-packing-api` must be **public** (the cluster has no
imagePullSecret). Flipping it is a one-time web-UI step; until then the pod will
`ImagePullBackOff`. Image contains no secrets (DB creds are injected at runtime).
