### PR TITLE
feat(auth): onboard read-only cognito viewer

### DIFF
--- a/infrastructure/terraform/aws/accounts/prod/cognito.tf
+++ b/infrastructure/terraform/aws/accounts/prod/cognito.tf
@@ -194,8 +194,8 @@ resource "aws_cognito_user_group" "agents" {
 
 ## ---------------------------------------------------------------------------------------------------------------------
 ## USERS
-## Human admin(s). Email is sourced from secrets.sops.yaml so the value
-## doesn't land in the public repo.
+## Human users (admin, viewer). Emails are sourced from secrets.sops.yaml so
+## the values don't land in the public repo.
 ##
 ## Pool's sign_in_policy enables PASSWORD as a first-auth factor, so
 ## AdminCreateUser requires a TemporaryPassword (AWS won't generate one
@@ -250,6 +250,46 @@ resource "aws_cognito_user_in_group" "admin_in_admins" {
   user_pool_id = aws_cognito_user_pool.tnwks_auth.id
   group_name   = aws_cognito_user_group.admins.name
   username     = aws_cognito_user.admin.username
+}
+
+# Read-only human user. Email sourced from secrets.sops.yaml (viewer_email)
+# so the address never lands in the public repo — same pattern as admin above.
+resource "random_password" "viewer_temp" {
+  length           = 24
+  special          = true
+  override_special = "!@#$%^&*()-_=+"
+
+  keepers = {
+    username        = data.sops_file.secrets.data["viewer_email"]
+    auth_posture    = "passkey-as-mfa-with-totp"
+    invite_template = "v2-onboard-tnwks-us"
+  }
+}
+
+resource "aws_cognito_user" "viewer" {
+  user_pool_id       = aws_cognito_user_pool.tnwks_auth.id
+  username           = data.sops_file.secrets.data["viewer_email"]
+  temporary_password = random_password.viewer_temp.result
+
+  attributes = {
+    email          = data.sops_file.secrets.data["viewer_email"]
+    email_verified = true
+  }
+
+  desired_delivery_mediums = ["EMAIL"]
+
+  lifecycle {
+    ignore_changes = [temporary_password]
+    replace_triggered_by = [
+      random_password.viewer_temp,
+    ]
+  }
+}
+
+resource "aws_cognito_user_in_group" "viewer_in_viewers" {
+  user_pool_id = aws_cognito_user_pool.tnwks_auth.id
+  group_name   = aws_cognito_user_group.viewers.name
+  username     = aws_cognito_user.viewer.username
 }
 
 ## ---------------------------------------------------------------------------------------------------------------------

--- a/infrastructure/terraform/aws/accounts/prod/secrets.sops.yaml
+++ b/infrastructure/terraform/aws/accounts/prod/secrets.sops.yaml
@@ -2,6 +2,7 @@ ses_domain: ENC[AES256_GCM,data:oh6+CPwYihE=,iv:CJb68N6knVR/iriISSBfpNF0LklUCdie
 smtp_username: ENC[AES256_GCM,data:UnF6ay7rDYH3DVXPOTEFAqHOPsM=,iv:GUtXTkJ3tJIvfDA3R/3hajucpd7XqRPfDr3D3PnYFxs=,tag:Sz9iNk3+GPNdM7ug41BH4w==,type:str]
 smtp_password: ENC[AES256_GCM,data:xr1fYWm8MEy/8sAJjAoRDGjh0zACf7JvX86M2PhuTBcwQxODIxTns4y/tjQ=,iv:uo7XdyVxDoQVcg91p02KO4f1HciR09q0i5tx/7VllQY=,tag:S1fIWP+TeAqoi9SN8UDgsg==,type:str]
 admin_email: ENC[AES256_GCM,data:6MVcLaRLOSclyapz1oQ9VOOdhPtDI99wBQ==,iv:WMiRMJAugEqHCa9mztJDuw/iBzqmbWqzHJ3SHvYbRcg=,tag:Q0oQpIOhAOE6cW72F4Hs/A==,type:str]
+viewer_email: ENC[AES256_GCM,data:ncxqRULHaiO7saoBUdDJskXVmgEA,iv:rtDDZgXDoy/AkhRhij54XbOmOC4D6BryAL7rraBNHFE=,tag:FL6TzXAnb7BvgS3b9RsQsw==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-west-2:654654220436:key/mrk-74c4597ebffd41d38a852228e13d76cc
@@ -40,8 +41,8 @@ sops:
             empQYkRVeWdjWHB1djVqcDlQTkZjV28KXZ/+sLAJW8DtVFs3l0fyBK2YamMZFIZS
             2hRpHpGNtq1vruXuOxhfhHX0GyDqZgWVh3q/Vdl3S+qe0ArE57gRBg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-26T15:39:00Z"
-    mac: ENC[AES256_GCM,data:uc63Cmcu4NZjUZ5mWoK2IPbVD9Rta/aA4rJRZuenVtkCQmGcDxp5sJM3bhmzSPPt+FBo0J+GrJvr8XDuJqnuGKDeOekrE9vuoLk2aCjhRBSEXTjwJpwy1Yb7xBiW4rzt5Abg0rBxT6IFm85kYBCerwSX8f9+8ESFJYR1KbG32Y4=,iv:8pX0WlfrtlWniB6Nmbcvnv+wZIkkDTLRkrvtLg50qG8=,tag:P1vafI++XRTnlz0fskHnUQ==,type:str]
+    lastmodified: "2026-06-08T02:41:52Z"
+    mac: ENC[AES256_GCM,data:xz6xM0PBLv08TeGjFuL//OfFQw5MwTDREde82+qCwi8VCsIl3kJH+rkqZObq8cnnqzphwriMZPYp59pzEE5M10GLwsbV3vCqt6MQtQJhucm6pk7+oHwFDsxlFDv5epdIA1iQIJOD5KlKG80hBhvz56oaEqdY0jC6b+2gDMAjWk8=,iv:JALVKhwaVy3ldlUPsBghQNd27WtNCBMAjYoNp1oqiek=,tag:lfSCeZh+gRKreuw2Fn6rqA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
## What

Adds a second human user to the `tnwks-auth` Cognito user pool, in the `viewers` group (read-only access to internal services).

## How

Follows the existing `admin` user pattern in `cognito.tf`:

- **Email is a secret** — stored as `viewer_email` in `secrets.sops.yaml` (AES256-GCM, same KMS MRK + age recipients as the other values), surfaced via `data.sops_file.secrets`. The address never lands in the public repo.
- **Temp password** generated by `random_password.viewer_temp`, rotated by the user on first login; lives in TF state only.
- Three resources mirror the admin block: `random_password.viewer_temp`, `aws_cognito_user.viewer`, `aws_cognito_user_in_group.viewer_in_viewers`.

## Naming

`viewer_email` parallels the existing `admin_email` — role-based and generic, so only "a viewer exists" is public (same posture as the admin). Single-block style kept intentionally; would move to `for_each` if viewer count grows.

## Validation

- `sops -d` round-trips the new key to the correct value
- plaintext email is **not** present in the diff
- `terraform fmt` — no changes
- `terraform validate` — Success

## Effect on apply (via TFC)

Cognito emails the new viewer a temporary password + onboarding link (`onboard.tnwks.us`); they enroll a passkey and land in the `viewers` group. No impact on the admin user, MFA, or managed-login provisioners.