### PR TITLE
feat(storage): add democratic-csi local-hostpath to homelab-wsl

### DIFF
--- a/kubernetes/apps/kube-system/democratic-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/democratic-csi/app/helmrelease.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: democratic-csi
+  namespace: kube-system
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: democratic-csi
+      version: 0.15.1
+      sourceRef:
+        kind: HelmRepository
+        name: democratic-csi
+        namespace: flux-system
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    # local-hostpath driver — provisions a directory under a host path and
+    # bind-mounts it into the workload pod. On this cluster every worker shares
+    # the same underlying filesystem (Talos-in-Docker on WSL2), so volumes are
+    # NOT pinned to a node. That's the whole point of choosing this over
+    # local-path-provisioner: no node affinity, so a PVC's pod can schedule on
+    # any node even when another goes NotReady.
+    csiDriver:
+      # Globally unique driver name for this cluster.
+      name: org.democratic-csi.local-hostpath
+
+    storageClasses:
+      - name: democratic-local
+        # Not the cluster default (yet) — flipping the default is a separate
+        # migration step so existing PVCs on local-path are left untouched.
+        defaultClass: false
+        reclaimPolicy: Delete
+        # Immediate, not WaitForFirstConsumer: with a shared filesystem there
+        # is no node to wait for, and Immediate avoids the scheduling deadlock
+        # local-path's node affinity creates when a node is NotReady.
+        volumeBindingMode: Immediate
+        allowVolumeExpansion: false
+        parameters:
+          fsType: ""
+
+    # The driver just creates directories — no NFS/iSCSI/ZFS backend.
+    driver:
+      config:
+        driver: local-hostpath
+        instance_id: homelab-wsl
+        local-hostpath:
+          # shareBasePath and controllerBasePath must match and must be
+          # mounted into both the controller and node driver containers
+          # (see extraVolumes / extraVolumeMounts below).
+          shareBasePath: /var/lib/democratic-csi/local-hostpath
+          controllerBasePath: /var/lib/democratic-csi/local-hostpath
+          dirPermissionsMode: "0777"
+          dirPermissionsUser: 0
+          dirPermissionsGroup: 0
+
+    # Mount the host base path into the controller container so it can create
+    # and delete volume directories.
+    controller:
+      driver:
+        extraVolumeMounts:
+          - name: local-hostpath
+            mountPath: /var/lib/democratic-csi/local-hostpath
+            mountPropagation: Bidirectional
+      extraVolumes:
+        - name: local-hostpath
+          hostPath:
+            path: /var/lib/democratic-csi/local-hostpath
+            type: DirectoryOrCreate
+
+    # Mount the same host base path into the node container so it can stage
+    # and publish volumes into workload pods.
+    node:
+      driver:
+        extraVolumeMounts:
+          - name: local-hostpath
+            mountPath: /var/lib/democratic-csi/local-hostpath
+            mountPropagation: Bidirectional
+      extraVolumes:
+        - name: local-hostpath
+          hostPath:
+            path: /var/lib/democratic-csi/local-hostpath
+            type: DirectoryOrCreate

--- a/kubernetes/apps/kube-system/democratic-csi/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/democratic-csi/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/democratic-csi/ks.yaml
+++ b/kubernetes/apps/kube-system/democratic-csi/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: democratic-csi
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/kube-system/democratic-csi/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false # no flux ks dependents
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/clusters/wsl/apps/kustomization.yaml
+++ b/kubernetes/clusters/wsl/apps/kustomization.yaml
@@ -32,6 +32,7 @@ resources:
   - ../../../apps/default
   - ../../../apps/flux-system
   - ../../../apps/kube-system
+  - ../../../apps/kube-system/democratic-csi/ks.yaml
   - ../../../apps/kube-system/flannel/ks.yaml
   - ../../../apps/kube-system/local-path-provisioner/ks.yaml
   - ../../../apps/media

--- a/kubernetes/clusters/wsl/cluster-settings.yaml
+++ b/kubernetes/clusters/wsl/cluster-settings.yaml
@@ -24,6 +24,15 @@ data:
   #                      PVCs (storageClassName is immutable).
   STORAGE_CLASS_DEFAULT: "local-path"
   STORAGE_CLASS_BULK: "local-path"
+  # democratic-local — democratic-csi local-hostpath driver. Provisions
+  # directories under /var/lib/democratic-csi/local-hostpath with NO node
+  # affinity (volumeBindingMode: Immediate), so a PVC's pod can schedule on
+  # any worker even when another is NotReady — unlike local-path, whose
+  # per-PV node affinity deadlocks scheduling when its node goes down.
+  # Opt-in for now; intended to become STORAGE_CLASS_DEFAULT in a later
+  # migration step (flipping the default is deferred so existing local-path
+  # PVCs are left untouched — storageClassName is immutable).
+  STORAGE_CLASS_DEMOCRATIC: "democratic-local"
   # Database (postgres) storage. Must support Linux permission semantics
   # (initdb chmods config files). The default local-path SC sits on a
   # Windows DrvFs bind-mount which doesn't, so postgres uses local-path-ext4

--- a/kubernetes/flux/meta/helm/democratic-csi.yaml
+++ b/kubernetes/flux/meta/helm/democratic-csi.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: democratic-csi
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://democratic-csi.github.io/charts/

--- a/kubernetes/flux/meta/helm/kustomization.yaml
+++ b/kubernetes/flux/meta/helm/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./bjw-s.yaml
   - ./cilium.yaml
   - ./cloudnative-pg.yaml
+  - ./democratic-csi.yaml
   - ./descheduler.yaml
   - ./emberstack.yaml
   - ./external-dns.yaml


### PR DESCRIPTION
## What

Adds the **democratic-csi `local-hostpath`** driver to the `homelab-wsl` cluster as a new, **opt-in** StorageClass: `democratic-local`.

## Why

`local-path-provisioner` pins every PV to a specific node via node affinity. On Talos-in-Docker-on-WSL2 all workers share the same underlying filesystem, so that affinity buys nothing — but it actively breaks scheduling: when a node goes `NotReady` (currently `worker-2`), pods bound to its PVs (Grafana, Alertmanager) get stranded in `Pending` even though any other worker could mount the exact same data.

`local-hostpath` provisions directories with **no node affinity** (`volumeBindingMode: Immediate`), which is correct for this shared-filesystem topology.

## Changes

- **HelmRepository** `kubernetes/flux/meta/helm/democratic-csi.yaml` (+ added to the meta `kustomization.yaml`)
- **App** `kubernetes/apps/kube-system/democratic-csi/` — `ks.yaml` + `app/{kustomization,helmrelease}.yaml`, chart pinned to `0.15.1`
  - StorageClass `democratic-local`, `volumeBindingMode: Immediate`, `reclaimPolicy: Delete`, **not** default
  - Base path `/var/lib/democratic-csi/local-hostpath`, mounted into both controller and node driver containers
  - No NFS/iSCSI backend — just creates directories
- **Wired** into `kubernetes/clusters/wsl/apps/kustomization.yaml` (next to `local-path-provisioner`)
- **cluster-settings**: added `STORAGE_CLASS_DEMOCRATIC: "democratic-local"`; `STORAGE_CLASS_DEFAULT` left as `local-path`

## Migration posture

This intentionally does **not** flip the cluster default. `storageClassName` is immutable on existing PVCs, so changing `STORAGE_CLASS_DEFAULT` now would orphan current local-path volumes. The default flip (and any per-PVC migration) is a deliberate follow-up — see the comment in `cluster-settings.yaml`.

## Validation

- \`kustomize build kubernetes/apps/kube-system/democratic-csi/app/\` — renders ✅
- \`kustomize build --load-restrictor LoadRestrictionsNone kubernetes/clusters/wsl/apps/\` — full overlay builds ✅ (the load-restrictor flag mirrors Flux's own setting; the existing flannel / local-path-provisioner `ks.yaml` refs require it too)
- \`kustomize build kubernetes/flux/meta/helm/\` — renders ✅

Fix-forward: merge → Flux reconciles. No `kubectl apply`.