### PR TITLE
fix(storage): drop Bidirectional mountPropagation from democratic-csi

### DIFF
--- a/kubernetes/apps/kube-system/democratic-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/democratic-csi/app/helmrelease.yaml
@@ -72,7 +72,6 @@ spec:
         extraVolumeMounts:
           - name: local-hostpath
             mountPath: /var/lib/democratic-csi/local-hostpath
-            mountPropagation: Bidirectional
       extraVolumes:
         - name: local-hostpath
           hostPath:
@@ -86,7 +85,6 @@ spec:
         extraVolumeMounts:
           - name: local-hostpath
             mountPath: /var/lib/democratic-csi/local-hostpath
-            mountPropagation: Bidirectional
       extraVolumes:
         - name: local-hostpath
           hostPath:


### PR DESCRIPTION
## Problem

The democratic-csi HelmRelease from #1307 **failed to install** on `homelab-wsl`:

\`\`\`
Helm install failed for release kube-system/democratic-csi:
Deployment.apps "democratic-csi-controller" is invalid:
spec.template.spec.containers[4].volumeMounts.mountPropagation:
Forbidden: Bidirectional mount propagation is available only to
privileged containers
\`\`\`

I added `mountPropagation: Bidirectional` to the controller and node `extraVolumeMounts`. The controller's provisioner sidecar isn't privileged, so the API server rejected the Deployment.

## Fix

Remove `mountPropagation` from both mounts. It isn't needed for `local-hostpath`:
- the **controller** only creates/deletes volume directories under the base path
- the **node** reads the base path; the actual bind-mount into the workload pod uses the chart's own kubelet hostPath volume, which already has correct propagation

This matches the upstream `local-hostpath` example, which sets no propagation at all.

## Validation

- \`kustomize build kubernetes/apps/kube-system/democratic-csi/app/\` ✅
- Caught post-merge via `flux get hr` per the AGENTS.md validate-after-reconcile flow; fixing forward.