### PR TITLE
fix(storage): disable external-resizer for democratic-csi local-hostpath

### DIFF
--- a/kubernetes/apps/kube-system/democratic-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/democratic-csi/app/helmrelease.yaml
@@ -68,6 +68,12 @@ spec:
     # Mount the host base path into the controller container so it can create
     # and delete volume directories.
     controller:
+      # The local-hostpath driver doesn't implement volume resize, so the
+      # external-resizer sidecar crashes on startup (NodeGetCapabilities
+      # returns Unimplemented). The StorageClass sets allowVolumeExpansion:
+      # false anyway, so the resizer has no job — disable it.
+      externalResizer:
+        enabled: false
       driver:
         extraVolumeMounts:
           - name: local-hostpath


### PR DESCRIPTION
## Problem

After #1308 the democratic-csi controller still crashlooped — the `external-resizer` sidecar (1 of 6 controller containers) failed on startup:

\`\`\`
failed to check if plugin supports node resize: rpc error:
code = Unimplemented desc = The server does not implement the
method /csi.v1.Node/NodeGetCapabilities
\`\`\`

The `local-hostpath` driver doesn't implement volume resize, so the resizer has nothing to talk to and dies, holding the controller pod in CrashLoopBackOff.

## Fix

Set `controller.externalResizer.enabled: false`. The `democratic-local` StorageClass already declares `allowVolumeExpansion: false`, so the resizer was dead weight regardless.

## Validation

- \`kustomize build kubernetes/apps/kube-system/democratic-csi/app/\` ✅
- Driver node DaemonSet + `democratic-local` StorageClass already healthy on-cluster; this clears the last crashlooping controller container.