### PR TITLE
feat(storage): make democratic-local the default StorageClass on WSL

### DIFF
--- a/kubernetes/clusters/wsl/cluster-settings.yaml
+++ b/kubernetes/clusters/wsl/cluster-settings.yaml
@@ -15,23 +15,28 @@ data:
   INTERNAL_DOMAIN: "internal.tnwks.us"
 
   # Storage classes
-  #   local-path       — default, on the Talos node container's overlay (C:)
+  #   democratic-local — DEFAULT. democratic-csi local-hostpath driver.
+  #                      Provisions directories under
+  #                      /var/lib/democratic-csi/local-hostpath with NO node
+  #                      affinity (volumeBindingMode: Immediate), so a PVC's
+  #                      pod can schedule on any worker even when another is
+  #                      NotReady. This is why it replaced local-path as the
+  #                      default: local-path pins each PV to a node and
+  #                      deadlocks scheduling when that node goes down.
+  #   local-path       — LEGACY default. Still present for PVCs not yet
+  #                      migrated (storageClassName is immutable, so existing
+  #                      volumes stay on it until they're recreated). Apps
+  #                      still on local-path: postgres (via DATABASE), valkey,
+  #                      plausible/clickhouse, mosquitto, nfs-server. These
+  #                      need real data migrations and will show a drifted
+  #                      HelmRelease until then (pods keep running).
   #   local-path-bulk  — pinned to homelab-wsl-worker-2, backed by Windows E:
   #                      via a /mnt/e bind-mount. Used directly by apps that
-  #                      need real disk (e.g. frigate recordings); not yet
-  #                      wired into STORAGE_CLASS_BULK because flipping that
-  #                      variable would invalidate existing qbit/jellyfin
-  #                      PVCs (storageClassName is immutable).
-  STORAGE_CLASS_DEFAULT: "local-path"
+  #                      need real disk (e.g. frigate recordings).
+  STORAGE_CLASS_DEFAULT: "democratic-local"
   STORAGE_CLASS_BULK: "local-path"
-  # democratic-local — democratic-csi local-hostpath driver. Provisions
-  # directories under /var/lib/democratic-csi/local-hostpath with NO node
-  # affinity (volumeBindingMode: Immediate), so a PVC's pod can schedule on
-  # any worker even when another is NotReady — unlike local-path, whose
-  # per-PV node affinity deadlocks scheduling when its node goes down.
-  # Opt-in for now; intended to become STORAGE_CLASS_DEFAULT in a later
-  # migration step (flipping the default is deferred so existing local-path
-  # PVCs are left untouched — storageClassName is immutable).
+  # Retained as an explicit handle for the local-hostpath class (same value
+  # as STORAGE_CLASS_DEFAULT now) so manifests that opted in early still work.
   STORAGE_CLASS_DEMOCRATIC: "democratic-local"
   # Database (postgres) storage. Must support Linux permission semantics
   # (initdb chmods config files). The default local-path SC sits on a


### PR DESCRIPTION
## What

Flips `STORAGE_CLASS_DEFAULT` from `local-path` → `democratic-local` on `homelab-wsl`.

## Why

`local-path` pins each PV to a node. When worker-2 went `NotReady`, every pod bound to a worker-2 PV stranded in `Pending` (Grafana, Alertmanager, and — via the Valkey/oauth2-proxy session store — the authed ingresses like onboard.tnwks.us). `democratic-local` (democratic-csi local-hostpath) provisions with **no node affinity** (`volumeBindingMode: Immediate`), correct for this shared-filesystem topology.

## Blast radius

**Non-destructive on its own.** `storageClassName` is immutable, so:
- Existing PVCs keep their class and their pods keep running.
- New PVCs provision on `democratic-local`.
- An app only actually moves when its PVC is **deleted and recreated** — done per-app in follow-up steps, not by this PR.

### Known drift
Stateful apps that still reference `${STORAGE_CLASS_DEFAULT}` but need a real data migration (postgres via `STORAGE_CLASS_DATABASE` is unaffected; **valkey, plausible/clickhouse, mosquitto, nfs-server** are) will report a **drifted/not-ready HelmRelease** — Flux can't patch an immutable field. **Their pods keep serving on the existing local-path volume.** This is expected and clears when each is migrated.

### Reversibility
Trivial: revert this one-line var change and reconcile.

## Validation
- `kustomize build kubernetes/clusters/wsl/apps/` (with Flux load-restrictor) ✅
- democratic-csi driver already healthy on-cluster (controller 5/5, node DaemonSet 4/4, `democratic-local` SC present).