### PR TITLE
fix(storage): revert WSL default to local-path; democratic-local unusable

### DIFF
--- a/kubernetes/clusters/wsl/cluster-settings.yaml
+++ b/kubernetes/clusters/wsl/cluster-settings.yaml
@@ -15,28 +15,31 @@ data:
   INTERNAL_DOMAIN: "internal.tnwks.us"
 
   # Storage classes
-  #   democratic-local — DEFAULT. democratic-csi local-hostpath driver.
-  #                      Provisions directories under
-  #                      /var/lib/democratic-csi/local-hostpath with NO node
-  #                      affinity (volumeBindingMode: Immediate), so a PVC's
-  #                      pod can schedule on any worker even when another is
-  #                      NotReady. This is why it replaced local-path as the
-  #                      default: local-path pins each PV to a node and
-  #                      deadlocks scheduling when that node goes down.
-  #   local-path       — LEGACY default. Still present for PVCs not yet
-  #                      migrated (storageClassName is immutable, so existing
-  #                      volumes stay on it until they're recreated). Apps
-  #                      still on local-path: postgres (via DATABASE), valkey,
-  #                      plausible/clickhouse, mosquitto, nfs-server. These
-  #                      need real data migrations and will show a drifted
-  #                      HelmRelease until then (pods keep running).
+  #   local-path       — DEFAULT. local-path-provisioner, on each Talos node
+  #                      container's overlay. Pins each PV to a node via node
+  #                      affinity (volumeBindingMode: WaitForFirstConsumer).
   #   local-path-bulk  — pinned to homelab-wsl-worker-2, backed by Windows E:
   #                      via a /mnt/e bind-mount. Used directly by apps that
   #                      need real disk (e.g. frigate recordings).
-  STORAGE_CLASS_DEFAULT: "democratic-local"
+  #
+  # NOTE: democratic-csi local-hostpath (democratic-local) is installed but is
+  # NOT usable as a general default on this cluster — see the comment on
+  # STORAGE_CLASS_DEMOCRATIC below. Do not point STORAGE_CLASS_DEFAULT at it.
+  STORAGE_CLASS_DEFAULT: "local-path"
   STORAGE_CLASS_BULK: "local-path"
-  # Retained as an explicit handle for the local-hostpath class (same value
-  # as STORAGE_CLASS_DEFAULT now) so manifests that opted in early still work.
+  # democratic-local — democratic-csi local-hostpath. Present on the cluster
+  # but BROKEN for real workloads here, for two independent reasons:
+  #   1. Talos-in-Docker nodes do NOT share a filesystem (each node is its own
+  #      container). local-hostpath creates the volume dir on the *controller*
+  #      node; with volumeBindingMode: Immediate the workload pod can land on a
+  #      different node where the dir doesn't exist -> NodeStageVolume fails
+  #      with "special device .../v/<pvc> does not exist".
+  #   2. The node driver runs `mount --bind`, but the Talos mount binary
+  #      rejects GNU long options ("illegal option -- -").
+  # Kept defined only so the HelmRelease/StorageClass reconcile cleanly; do
+  # NOT route app PVCs here until both issues are solved at the Talos/Docker
+  # bootstrap layer (shared host volume bind-mounted into every node + a
+  # mount-binary fix). See PR history for the investigation.
   STORAGE_CLASS_DEMOCRATIC: "democratic-local"
   # Database (postgres) storage. Must support Linux permission semantics
   # (initdb chmods config files). The default local-path SC sits on a


### PR DESCRIPTION
## TL;DR

Reverts `STORAGE_CLASS_DEFAULT` → `local-path`. **democratic-csi local-hostpath does not work on this cluster.** Discovered by canary-migrating recyclarr before batching the rest — which is exactly why only one app was touched.

## Why it fails (two independent, fatal reasons)

### 1. The nodes do NOT share a filesystem
The original task premise ("all worker nodes share the same underlying filesystem") is false. Each Talos-in-Docker node is a **separate container with its own FS**. `local-hostpath` creates the volume dir on the node where the **controller** runs; with `volumeBindingMode: Immediate` the **workload** pod can schedule on a different node, where the dir doesn't exist:

\`\`\`
NodeStageVolume error: special device
/var/lib/democratic-csi/local-hostpath/v/pvc-... does not exist
\`\`\`

Proof — the directory exists on worker-1 (controller) but not worker-2 (workload):
\`\`\`
worker-1: drwxrwxrwx pvc-e30531d8-...
worker-2: ls: cannot access '.../v/': No such file or directory
\`\`\`

This is **worse** than local-path, which at least co-located the pod with its data.

### 2. Talos `mount` rejects the driver's flags
Even co-located it would fail. The node driver runs `mount --bind`; Talos's mount binary doesn't accept GNU long options:
\`\`\`
/usr/local/bin/mount: illegal option -- -
\`\`\`

## What this PR does / doesn't do

- ✅ Reverts the default so no further PVCs land on the broken class.
- ✅ Documents both failure modes inline in `cluster-settings.yaml`.
- ⚠️ Leaves the democratic-csi HelmRelease + StorageClass **installed** (they reconcile cleanly; harmless while unused). Removing them can be a separate cleanup if desired.
- 🔧 **recyclarr** was the canary; its PVC is on the broken class. After this merges + reconciles I'll recreate it back onto local-path (one app, scratch data).

## Path forward (not in this PR)
Making local-hostpath viable needs **Talos/Docker bootstrap** changes, not manifests: a single shared host directory bind-mounted into every node container at the same path, plus a fix for the mount-binary incompatibility. Until then, the node-affinity-deadlock problem is better addressed another way (e.g. keeping worker-2 healthy, or a real shared-storage backend like NFS/Ceph).

## Validation
- `kustomize build kubernetes/clusters/wsl/apps/` (Flux load-restrictor) ✅
- Root cause captured from live controller + node driver logs (quoted above).