### PR TITLE
fix(wsl): auto-attach USB dongles on reboot + Z-Stick live-bind parity

### DIFF
--- a/docs/usb-passthrough.md
+++ b/docs/usb-passthrough.md
@@ -59,6 +59,25 @@ usbipd attach --wsl --busid 2-3
 usbipd attach --wsl --busid 4-1
 ```
 
+> **Don't do the attach by hand on every reboot — register the task.**
+> `usbipd bind` is persistent but `usbipd attach --wsl` is per-session, so a
+> Windows reboot or `wsl --shutdown` drops both dongles out of WSL and the
+> frigate / zwave-js-ui pods break. `infrastructure/wsl-host/` ships a
+> Scheduled Task that re-attaches them automatically at logon and when the
+> WSL VM reconnects (matches `vmid` by VID:PID, not busid). Register it once,
+> elevated:
+>
+> ```powershell
+> cd <repo>\infrastructure\wsl-host
+> .\Register-TnwksUsbAttachTask.ps1
+> Start-ScheduledTask -TaskName tnwks-usb-attach   # run it now
+> ```
+>
+> `Sync-TnwksUsbAttach.ps1` is idempotent — it binds (with `--force`) and
+> attaches any target dongle that's connected but not yet attached, and
+> leaves already-attached ones alone. The Coral firmware flip still needs a
+> manual nudge in the worst case (see the gotcha below).
+
 > **Coral gotcha — bind after firmware loads, not before.** When the
 > Coral first appears on Windows it shows VID/PID `1a6e:089a` (DFU
 > bootloader). Windows itself completes the firmware load, after which
@@ -100,10 +119,11 @@ the base64 machine config in `USERDATA`), and recreates the container
 via `community.docker.docker_container` with the USB passthrough and
 `/mnt/e/k8s-storage` bind-mount layered on top.
 
-The Coral comes through as an **`rslave` bind mount** of `/dev/bus/usb`
-(not a `--device`), so host re-enumeration propagates live — see the
-`--device` caveat below. The Z-Stick stays a `--device` because Talos
-runs no udev to recreate its node on re-enum (see `/dev/ttyACM0` note).
+Both dongles come through as **`rslave` bind mounts** (not `--device`), so
+host re-enumeration — and a dongle attached *after* the container started —
+propagates the live node in. The Coral binds `/dev/bus/usb`; the Z-Stick
+binds the whole host `/dev` tree at a dedicated `/hostdev` mountpoint (its
+CDC tty's only parent dir is `/dev` itself). See the `--device` caveat below.
 
 ```bash
 cd infrastructure
@@ -127,43 +147,47 @@ named volume); drain just relocates pods that can move.
 ### Verify the device made it through
 
 ```bash
-talosctl -n 10.5.0.4 ls /dev/bus/usb       # should list 001, 002 ...
-talosctl -n 10.5.0.4 ls /dev | grep ttyACM # Z-Stick lands here
+talosctl -n 10.5.0.4 ls /dev/bus/usb        # Coral: should list 001, 002 ...
+talosctl -n 10.5.0.4 ls /hostdev | grep ttyACM  # Z-Stick lands here
 ```
 
-> **Why `/dev/ttyACM0` and not `/dev/serial/by-id/...`?** Talos doesn't
-> populate udev's `/dev/serial/by-id/` symlinks. Docker resolves the
-> host symlink at container start, so the device node arrives as
-> `/dev/ttyACM0` inside the Talos container. The WSL overlay
+> **Why `/hostdev/ttyACM0` and not `/dev/serial/by-id/...`?** Talos
+> doesn't populate udev's `/dev/serial/by-id/` symlinks, so the Z-Stick
+> arrives as the bare `ttyACM0` node. worker-2 bind-mounts the host's
+> `/dev` at `/hostdev`, so the device is at `/hostdev/ttyACM0` inside the
+> container. The WSL overlay
 > (`kubernetes/clusters/wsl/apps/home-automation/zwave-js-ui-ks.yaml`)
 > patches the zwave-js-ui hostPath accordingly. The MS-01 cluster keeps
 > the upstream by-id path because udev runs there.
 
 > **`--device` is a snapshot, not a live mount.** Docker's `--device`
 > flag captures the host's device-node major/minor at container start
-> and cgroup-allows that exact one. If the underlying USB device
-> disconnects/reconnects later (USB reset, suspend, replug, or a
-> usbipd `detach`/`attach` cycle), the host renumbers it but the Talos
-> container still has the stale node. The pod then sees a dangling
-> /dev entry or opens the wrong device.
+> and cgroup-allows that exact one. If the device isn't present yet at
+> container start (attached later), or disconnects/reconnects (USB reset,
+> suspend, replug, usbipd `detach`/`attach`), the container is left with
+> no node or a stale one. The pod then can't open the device:
+> `libedgetpu` fails to load, or the kubelet rejects the zwave hostPath
+> with `/dev/ttyACM0 is not a character device`.
 >
-> **The Coral avoids this** — the playbook bind-mounts `/dev/bus/usb`
-> with `rslave` propagation instead of using `--device`. New
-> `/dev/bus/usb/<bus>/<dev>` nodes created on the host when the Coral
-> re-enumerates propagate into the container live, so `libedgetpu`
-> always finds the current `18d1:9302` and Frigate no longer CrashLoops
-> after a usbipd cycle. `privileged: true` (already set on the worker
-> container) grants the device-cgroup access the bind mount needs. The
-> pod-side `hostPath` mount carries the matching
-> `mountPropagation: HostToContainer` so the new node reaches the
-> Frigate container too.
+> **Both dongles avoid this with `rslave` bind mounts** instead of
+> `--device`, so nodes created on the host propagate into the container
+> live. `privileged: true` (already set on the worker container) grants
+> the device-cgroup access the bind mounts need, and the pod-side
+> `hostPath` mounts carry the matching `mountPropagation: HostToContainer`
+> so the live node reaches the app container too.
 >
-> **The Z-Stick stays a `--device`.** Talos runs no udev, so it cannot
-> recreate a CDC node on re-enum the way the kernel does for
-> `/dev/bus/usb`; bind-propagating `/dev/ttyACM0` would gain nothing,
-> and bind-mounting all of `/dev` into the Talos worker is too invasive.
-> If the Z-Stick re-enumerates, re-run the playbook (it recreates
-> worker-2 after the device is back in a stable state).
+> - **Coral** binds `/dev/bus/usb` directly — `libedgetpu` speaks raw
+>   usbfs nodes and the subtree is self-contained, so new
+>   `/dev/bus/usb/<bus>/<dev>` nodes from a firmware-flip re-enumeration
+>   appear in the pod and Frigate finds the current `18d1:9302`.
+> - **Z-Stick** binds the whole host `/dev` at **`/hostdev`** (a dedicated
+>   mountpoint, *not* over the container's own `/dev`). zwave-js-ui opens a
+>   CDC tty whose only parent dir is `/dev` itself; overlaying the
+>   container's `/dev` would shadow Talos's `/dev/pts`, `/dev/shm` and
+>   submounts and break the node, so it gets its own path. The live
+>   `/hostdev/ttyACM0` appears even when the Z-Stick is attached after
+>   worker-2 started — which is exactly the host-reboot ordering that used
+>   to wedge the pod.
 
 ---
 
@@ -206,7 +230,8 @@ persistence:
     hostPathType: CharDevice
 ```
 
-The WSL overlay patches this to `/dev/ttyACM0` and pins the pod to
+The WSL overlay patches this to `/hostdev/ttyACM0` (the host `/dev` tree is
+bind-mounted into worker-2 at `/hostdev`) and pins the pod to
 `homelab-wsl-worker-2`:
 
 ```
@@ -245,14 +270,16 @@ usbipd list                                    # device should be 'Attached'
 lsusb | grep -E "Coral|Aeotec|Sigma|Google"
 ls /dev/bus/usb/*/
 
-# Talos node container (replace <node> with the node name)
+# Talos node container (replace <node> with the node name).
+# On WSL the Z-Stick is under /hostdev; on MS-01 it's /dev/serial/by-id.
 talosctl -n <node> ls /dev/bus/usb
-talosctl -n <node> ls /dev/serial/by-id
+talosctl -n <node> ls /hostdev | grep ttyACM    # WSL
+talosctl -n <node> ls /dev/serial/by-id         # MS-01
 
 # Pod
 kubectl exec -n production deploy/frigate -- ls /dev/bus/usb
 kubectl exec -n home-automation deploy/zwave-js-ui -- \
-  ls -l /dev/serial/by-id
+  ls -l /hostdev/ttyACM0                          # WSL (by-id on MS-01)
 ```
 
 If any layer doesn't see the device, fix that layer before going up.
@@ -263,11 +290,11 @@ If any layer doesn't see the device, fix that layer before going up.
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `usbipd list` shows device but `lsusb` in WSL is empty | Forgot `attach` after WSL restart | `usbipd attach --wsl --busid X-Y` |
-| Device disappears after Windows reboot | `bind` is persistent; `attach` is per-session | Re-run `attach` in startup script |
-| Pod crashes with "no such device" | Talos node container doesn't see the device | Re-do Step 2 |
-| Coral throws permission errors | Coral firmware load flips vendor:product, breaks bind | Re-bind with new busid after first run |
-| Z-Wave controller "stuck" | wrong CDC path in hostPath | `talosctl -n <node> ls /dev/serial/by-id`, update the helmrelease |
+| `usbipd list` shows device but `lsusb` in WSL is empty | Forgot `attach` after WSL restart | `Start-ScheduledTask -TaskName tnwks-usb-attach` (or `usbipd attach --wsl --busid X-Y`) |
+| Devices drop out after every Windows reboot | `bind` is persistent; `attach` is per-session, and the auto-attach task isn't registered | Register it: `.\Register-TnwksUsbAttachTask.ps1` (elevated) |
+| Pod crashes with "no such device" / zwave "is not a character device" | worker-2 container doesn't see the live node (stale `--device` snapshot, or attached after container start) | Re-run `task bootstrap:wsl` to recreate worker-2 with the `rslave` binds (Step 2) |
+| Coral throws permission errors / `Failed to load delegate` | Coral firmware flip kicked it back to the Windows host at `18d1:9302` | Re-run `tnwks-usb-attach`, or manually re-bind/attach the runtime VID (see Coral gotcha) |
+| Z-Wave controller "stuck" | wrong CDC path in hostPath | `talosctl -n <node> ls /hostdev \| grep ttyACM` (WSL) and confirm the overlay path |
 
 ## References
 

--- a/infrastructure/ansible/playbooks/01-talos-bootstrap.yml
+++ b/infrastructure/ansible/playbooks/01-talos-bootstrap.yml
@@ -118,6 +118,11 @@
             path: "{{ zstick_path }}"
           register: zstick_stat
 
+        - name: Check whether host /dev tree is present
+          ansible.builtin.stat:
+            path: /dev
+          register: host_dev_stat
+
         - name: Skip augmentation when neither USB nor bulk path is available
           ansible.builtin.debug:
             msg: |
@@ -134,38 +139,54 @@
             name: "{{ worker_name }}"
           register: w2_info
 
-        # The Coral is bind-mounted (not --device) with rslave propagation so
-        # host re-enumeration (usbipd detach/attach, firmware reload) makes
-        # the new /dev/bus/usb/<bus>/<dev> node appear inside the container
-        # live. A --device flag snapshots the major/minor at container start
-        # and goes stale on re-enum — libedgetpu in Frigate then finds no
-        # 18d1:9302 and CrashLoops. privileged: true already grants the
-        # device-cgroup access the bind mount needs. The Z-Stick stays a
-        # --device: Talos runs no udev, so /dev/serial/by-id is never
-        # populated and the CDC node arrives as /dev/ttyACM0 (the zwave-js-ui
-        # WSL overlay points at that path). See docs/usb-passthrough.md.
+        # Both USB devices reach worker-2 as rslave bind mounts (not --device)
+        # so host re-enumeration — usbipd detach/attach, Coral firmware reload,
+        # or a Z-Stick attached *after* the container started — propagates the
+        # live device node into the container. A --device flag snapshots the
+        # major/minor at container start and goes stale on re-enum (or is never
+        # created at all if the device wasn't attached yet): libedgetpu then
+        # finds no 18d1:9302 and Frigate CrashLoops, and zwave-js-ui's kubelet
+        # mount fails with "/dev/ttyACM0 is not a character device".
+        # privileged: true already grants the device-cgroup access bind mounts
+        # need.
+        #
+        #   - Coral: bind /dev/bus/usb (libedgetpu speaks raw usbfs nodes, and
+        #     the subtree is self-contained, so it mounts directly).
+        #   - Z-Stick: bind the whole host /dev at a *dedicated* /hostdev
+        #     mountpoint, NOT over the container's own /dev. zwave-js-ui opens
+        #     a CDC tty (/dev/ttyACM0), whose only parent dir is /dev itself;
+        #     overlaying the container's /dev would shadow Talos's /dev/pts,
+        #     /dev/shm and submounts and break the node. The zwave-js-ui WSL
+        #     overlay points the pod hostPath at /hostdev/ttyACM0 to match.
+        # See docs/usb-passthrough.md.
         - name: Build desired device list
           ansible.builtin.set_fact:
-            w2_devices: >-
-              {{ [ zstick_path ~ ':' ~ zstick_path ~ ':rwm' ] if zstick_stat.stat.exists else [] }}
+            w2_devices: []
 
         - name: Build desired bind-mount list
           ansible.builtin.set_fact:
             w2_bind_mounts: >-
               {{
                 ([ '/dev/bus/usb:/dev/bus/usb:rslave' ] if usb_bus_stat.stat.exists else [])
+                + ([ '/dev:/hostdev:rslave' ] if host_dev_stat.stat.exists else [])
                 + ([ bulk_host_path ~ ':' ~ bulk_host_path ] if bulk_path_stat.stat.exists else [])
               }}
 
-        # /dev/bus/usb is now an rslave bind, so look in Binds (not Devices).
-        # A container still carrying the old --device form has no matching
-        # bind here, so this stays false and triggers the migrating recreate.
+        # Both USB passthroughs are now rslave binds, so look in Binds (not
+        # Devices). A container still carrying the old --device form (or
+        # lacking the /hostdev bind) has no matching entry here, so the flag
+        # stays false and triggers the migrating recreate.
         - name: Detect whether worker-2 already has the desired augmentations
           ansible.builtin.set_fact:
             w2_has_usb: >-
               {{ usb_bus_stat.stat.exists | bool
                  and (w2_info.container.HostConfig.Binds | default([]))
                        | select('match', '^/dev/bus/usb:')
+                       | list | length > 0 }}
+            w2_has_hostdev: >-
+              {{ host_dev_stat.stat.exists | bool
+                 and (w2_info.container.HostConfig.Binds | default([]))
+                       | select('match', '^/dev:/hostdev:')
                        | list | length > 0 }}
             w2_has_bulk: >-
               {{ bulk_path_stat.stat.exists | bool
@@ -177,6 +198,7 @@
           when:
             - w2_info.exists
             - (usb_bus_stat.stat.exists and not w2_has_usb)
+              or (host_dev_stat.stat.exists and not w2_has_hostdev)
               or (bulk_path_stat.stat.exists and not w2_has_bulk)
           block:
             - name: Capture original named volumes from worker-2

--- a/infrastructure/wsl-host/Register-TnwksUsbAttachTask.ps1
+++ b/infrastructure/wsl-host/Register-TnwksUsbAttachTask.ps1
@@ -1,0 +1,83 @@
+# Register-TnwksUsbAttachTask.ps1
+#
+# One-shot setup: registers a Scheduled Task that re-attaches the homelab USB
+# dongles (Z-Stick, Coral) into the WSL2 VM via usbipd-win whenever the attach
+# can be lost — at user logon (catches reboot + WSL cold start) and when the
+# Hyper-V vmswitch logs the WSL VM coming up. Run elevated, once.
+#
+# Companion to Register-TnwksLanBridgeTask.ps1 — same trigger strategy, but a
+# separate task because the concerns are unrelated (USB passthrough vs LAN
+# portproxy) and each runs its own sync script.
+
+[CmdletBinding()]
+param(
+    [string]$ScriptPath = (Join-Path $PSScriptRoot 'Sync-TnwksUsbAttach.ps1'),
+    [string]$TaskName   = 'tnwks-usb-attach'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $ScriptPath)) {
+    throw "Sync script not found at $ScriptPath"
+}
+
+$id = [Security.Principal.WindowsIdentity]::GetCurrent()
+$p  = New-Object Security.Principal.WindowsPrincipal($id)
+if (-not $p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw 'Register-TnwksUsbAttachTask.ps1 must be run as Administrator.'
+}
+
+$action = New-ScheduledTaskAction `
+    -Execute 'powershell.exe' `
+    -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$ScriptPath`""
+
+# Trigger 1: every user logon (catches reboot + WSL cold start).
+$logonTrigger = New-ScheduledTaskTrigger -AtLogOn
+
+# Trigger 2: Hyper-V vmswitch logs event 232 when a new VM NIC connects —
+# close enough to "WSL just (re)started" to re-attach after a mid-session
+# `wsl --shutdown`. usbipd needs the WSL VM up to attach into it, so reacting
+# to the vmswitch event lands the attach right after the VM is reachable.
+$cim = New-CimInstance -CimClass (
+    Get-CimClass -ClassName MSFT_TaskEventTrigger -Namespace Root/Microsoft/Windows/TaskScheduler
+) -ClientOnly -Property @{
+    Enabled      = $true
+    Subscription = @"
+<QueryList>
+  <Query Id="0" Path="Microsoft-Windows-Hyper-V-VmSwitch-Operational">
+    <Select Path="Microsoft-Windows-Hyper-V-VmSwitch-Operational">
+      *[System[Provider[@Name='Microsoft-Windows-Hyper-V-VmSwitch'] and (EventID=232)]]
+    </Select>
+  </Query>
+</QueryList>
+"@
+}
+
+# Small delay on the vmswitch trigger: the VM NIC event fires before WSL is
+# fully reachable for `usbipd attach`. 15s is comfortably past that.
+$cim.Delay = 'PT15S'
+
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -MultipleInstances IgnoreNew
+
+# Run as SYSTEM so the attach doesn't need an interactive admin session.
+# usbipd attach --wsl targets the default WSL distro regardless of the
+# invoking user's session.
+$principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest
+
+if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+}
+
+Register-ScheduledTask `
+    -TaskName  $TaskName `
+    -Action    $action `
+    -Trigger   @($logonTrigger, $cim) `
+    -Settings  $settings `
+    -Principal $principal | Out-Null
+
+Write-Host "Scheduled Task '$TaskName' registered."
+Write-Host "Run it now with: Start-ScheduledTask -TaskName $TaskName"

--- a/infrastructure/wsl-host/Sync-TnwksUsbAttach.ps1
+++ b/infrastructure/wsl-host/Sync-TnwksUsbAttach.ps1
@@ -1,0 +1,95 @@
+# Sync-TnwksUsbAttach.ps1
+#
+# Re-attaches the homelab USB dongles (Aeotec Z-Stick, Google Coral TPU) into
+# the WSL2 VM via usbipd-win. `usbipd bind` is persistent across reboots but
+# `usbipd attach --wsl` is per-session: after a Windows reboot or
+# `wsl --shutdown` the dongles drop out of WSL and the frigate / zwave-js-ui
+# pods CrashLoop (no Coral) or fail to mount (no /dev/ttyACM0). A Scheduled
+# Task runs this at logon and whenever the WSL VM reconnects so the attach is
+# restored automatically. See docs/usb-passthrough.md.
+#
+# Run elevated. Idempotent — devices already attached are left alone.
+#
+# Devices are matched by VID:PID (from the USB InstanceId), NOT busid, because
+# the busid can change across reboots/replug.
+
+[CmdletBinding()]
+param(
+    # VID:PID of each dongle to keep attached. The Coral lists two: 18d1:9302
+    # (runtime, preferred) and 1a6e:089a (DFU bootloader, before firmware
+    # loads). We attach whichever is present — see the Coral note below.
+    [string[]]$TargetVidPids = @(
+        '0658:0200',   # Aeotec Z-Stick Gen5 (Sigma Designs CDC ACM)
+        '18d1:9302',   # Google Coral TPU — runtime VID (preferred)
+        '1a6e:089a'    # Google Coral TPU — DFU bootloader VID
+    )
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Require-Admin {
+    $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $p  = New-Object Security.Principal.WindowsPrincipal($id)
+    if (-not $p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        throw 'Sync-TnwksUsbAttach.ps1 must be run as Administrator.'
+    }
+}
+
+function Get-UsbipdDevices {
+    # `usbipd state` emits JSON: { "Devices": [ { BusId, InstanceId,
+    # ClientIPAddress, ... } ] }. ClientIPAddress is non-empty when the device
+    # is attached to a client (the WSL VM). InstanceId carries VID_/PID_.
+    $raw = & usbipd state 2>$null
+    if (-not $raw) { throw 'usbipd state returned nothing — is usbipd-win installed?' }
+    $state = $raw | ConvertFrom-Json
+    foreach ($d in $state.Devices) {
+        $vidpid = $null
+        if ($d.InstanceId -match 'VID_([0-9A-Fa-f]{4})&PID_([0-9A-Fa-f]{4})') {
+            $vidpid = ('{0}:{1}' -f $Matches[1], $Matches[2]).ToLower()
+        }
+        [pscustomobject]@{
+            BusId      = $d.BusId
+            VidPid     = $vidpid
+            Attached   = -not [string]::IsNullOrWhiteSpace($d.ClientIPAddress)
+            Connected  = -not [string]::IsNullOrWhiteSpace($d.BusId)
+        }
+    }
+}
+
+Require-Admin
+
+$devices = @(Get-UsbipdDevices | Where-Object { $_.Connected -and $_.VidPid })
+
+foreach ($vidpid in $TargetVidPids) {
+    $match = $devices | Where-Object { $_.VidPid -eq $vidpid.ToLower() } | Select-Object -First 1
+    if (-not $match) {
+        Write-Host "skip $vidpid - not connected"
+        continue
+    }
+    if ($match.Attached) {
+        Write-Host "ok   $vidpid (busid $($match.BusId)) - already attached"
+        continue
+    }
+    # bind --force is persistent and safe to repeat; ensures the device is
+    # shared before we attach. Then attach into the WSL VM.
+    & usbipd bind --force --busid $match.BusId 2>&1 | Out-Null
+    & usbipd attach --wsl --busid $match.BusId 2>&1 | Out-Null
+    Write-Host "attached $vidpid (busid $($match.BusId))"
+}
+
+# Coral gotcha — automation cannot fully resolve the firmware flip.
+# When the Coral is attached at the bootloader VID (1a6e:089a) and the frigate
+# pod first opens it, libedgetpu uploads firmware; the device resets and
+# re-enumerates at the runtime VID (18d1:9302), which on a usbip link pops the
+# device back onto the Windows host as a *new, unattached* device. This task
+# re-attaches it on the next trigger (WSL reconnect / logon), but if frigate is
+# CrashLooping faster than the trigger fires, attach the runtime VID by hand:
+#   usbipd detach --busid <busid>
+#   usbipd list                       # wait for 18d1:9302
+#   usbipd bind  --busid <busid> --force
+#   usbipd attach --wsl --busid <busid>
+# See docs/usb-passthrough.md "Coral gotcha".
+
+Write-Host ''
+Write-Host 'Final usbipd state:'
+& usbipd list

--- a/kubernetes/clusters/wsl/apps/home-automation/zwave-js-ui-ks.yaml
+++ b/kubernetes/clusters/wsl/apps/home-automation/zwave-js-ui-ks.yaml
@@ -1,9 +1,13 @@
 ---
 # WSL overlay for zwave-js-ui: pin to homelab-wsl-worker-2 (the only node
-# with the Aeotec Z-Stick passed through via --device) and re-point the
-# usb hostPath at /dev/ttyACM0. Talos doesn't populate udev's
-# /dev/serial/by-id/ symlinks, but Docker resolves the host symlink at
-# container start so the device node arrives as /dev/ttyACM0.
+# with the Aeotec Z-Stick) and re-point the usb hostPath at
+# /hostdev/ttyACM0. worker-2 bind-mounts the host's /dev tree at /hostdev
+# with rslave propagation (see 01-talos-bootstrap.yml), mirroring the Coral
+# /dev/bus/usb bind: the live CDC tty node propagates in even when the
+# Z-Stick is attached after the container started, so a host reboot no
+# longer wedges the pod with a stale --device snapshot. It lands at
+# /hostdev/ttyACM0 (not /dev/serial/by-id/...) because Talos runs no udev
+# to populate the by-id symlinks.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -29,7 +33,7 @@ spec:
           value: homelab-wsl-worker-2
         - op: replace
           path: /spec/values/persistence/usb/hostPath
-          value: /dev/ttyACM0
+          value: /hostdev/ttyACM0
         - op: replace
           path: /spec/values/persistence/usb/globalMounts/0/path
-          value: /dev/ttyACM0
+          value: /hostdev/ttyACM0


### PR DESCRIPTION
## Problem

A Windows host reboot took down **frigate/Coral** and **zwave-js-ui/Z-Stick**.

Root cause: `usbipd bind` is persistent across reboots but `usbipd attach --wsl` is **per-session**, and nothing re-ran it. There was never a usbipd scheduled task — the existing `tnwks-lan-bridge` task is unrelated (portproxy).

- **Coral** recovered with a manual re-attach: its `/dev/bus/usb` `rslave` bind mount (from #1302) picks up the live node.
- **Z-Stick** stayed wedged in `ContainerCreating` (`/dev/ttyACM0 is not a character device`) because worker-2 passed it as a Docker `--device` — a node snapshot taken at container start, *before* the dongle was attached, so it never existed in the container. A fresh `usbipd attach` can't fix a stale `--device` snapshot.

## Fix (two layers)

**1. Windows host — auto-attach on reboot**
- `infrastructure/wsl-host/Sync-TnwksUsbAttach.ps1` — idempotently binds (`--force`) + attaches any target dongle (Z-Stick, Coral) that's connected but not attached. Matches by **VID:PID, not busid** (busid changes on replug).
- `infrastructure/wsl-host/Register-TnwksUsbAttachTask.ps1` — registers a Scheduled Task triggered at logon and on Hyper-V vmswitch reconnect (15s delay so WSL is reachable). Mirrors `Register-TnwksLanBridgeTask.ps1`; kept as a **separate task** since USB passthrough and LAN portproxy are unrelated concerns.

**2. worker-2 — Z-Stick parity with the Coral**
- Bootstrap playbook now binds the host `/dev` tree at a dedicated **`/hostdev`** mountpoint with `rslave` propagation instead of passing the Z-Stick as `--device`. The live CDC tty propagates in even when attached after container start.
- `/hostdev` rather than overlaying the container's own `/dev` — that would shadow Talos's `/dev/pts`, `/dev/shm` submounts and break the node. (This is the one intentional deviation from "exactly like the Coral", which can bind its self-contained `/dev/bus/usb` subtree directly.)
- Idempotency check learns the new `/dev:/hostdev:` bind, so a stale container triggers the migrating recreate.
- zwave-js-ui WSL overlay repoints `hostPath` → `/hostdev/ttyACM0`.

## Validation
- `ansible-playbook --syntax-check` on `01-talos-bootstrap.yml` — passes.
- `yq` parse of the zwave overlay — valid.
- Non-mutating only; no out-of-band cluster changes (GitOps — heals on merge + the post-merge runbook below).

## Post-merge runbook
1. On the Windows host (elevated), register the task once:
   ```powershell
   cd <repo>\infrastructure\wsl-host
   .\Register-TnwksUsbAttachTask.ps1
   Start-ScheduledTask -TaskName tnwks-usb-attach
   ```
2. After Flux syncs the overlay, recreate worker-2 so the `/hostdev` bind takes effect (drains worker-2; bounces Frigate, which re-settles the Coral):
   ```bash
   task bootstrap:wsl   # or just the 01-talos-bootstrap playbook
   ```
3. Verify: `kubectl -n home-automation get pods -l app.kubernetes.io/name=zwave-js-ui` → Running; `talosctl -n 10.5.0.4 ls /hostdev | grep ttyACM`.