### PR TITLE
fix(wsl): clear zwave hostPathType so /hostdev/ttyACM0 mount validates

### DIFF
--- a/kubernetes/clusters/wsl/apps/home-automation/zwave-js-ui-ks.yaml
+++ b/kubernetes/clusters/wsl/apps/home-automation/zwave-js-ui-ks.yaml
@@ -8,6 +8,17 @@
 # longer wedges the pod with a stale --device snapshot. It lands at
 # /hostdev/ttyACM0 (not /dev/serial/by-id/...) because Talos runs no udev
 # to populate the by-id symlinks.
+#
+# hostPathType is also cleared to "" (no validation). On WSL the worker
+# kubelet runs as a nested container whose mount namespace only carries the
+# worker's own /dev, NOT the sibling /hostdev bind — so a `CharDevice`
+# precheck stats a path the kubelet can't see and fails with "not a
+# character device". containerd (running in the worker's main namespace,
+# where /hostdev IS present) does the real mount, so skipping the kubelet
+# precheck lets the live node through. The Coral sidesteps this because its
+# mount lives under /dev (hostPathType: Directory just checks the dir
+# exists). MS-01 keeps CharDevice — udev runs there and the device is a
+# normal /dev node.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -34,6 +45,9 @@ spec:
         - op: replace
           path: /spec/values/persistence/usb/hostPath
           value: /hostdev/ttyACM0
+        - op: replace
+          path: /spec/values/persistence/usb/hostPathType
+          value: ""
         - op: replace
           path: /spec/values/persistence/usb/globalMounts/0/path
           value: /hostdev/ttyACM0


### PR DESCRIPTION
## Problem

Follow-up to #1313. That PR repointed the WSL zwave-js-ui hostPath to `/hostdev/ttyACM0` but kept `hostPathType: CharDevice`. The pod stuck in `ContainerCreating`:

```
MountVolume.SetUp failed for volume "usb":
hostPath type check failed: /hostdev/ttyACM0 is not a character device
```

`talosctl -n 10.5.0.4 ls -l /hostdev/ttyACM0` confirms it **is** a char device (`Dcrw-rw----`) — the kubelet just can't see that path.

## Root cause (verified from mount namespaces)

The worker-2 **kubelet runs as a nested container** (its own mount namespace). That namespace receives the worker's own `/dev` but **not** the top-level sibling `/hostdev` bind — `/proc/<kubelet>/mountinfo` shows zero `/hostdev` entries. So the kubelet's `CharDevice` precheck stats a path it can't see and fails.

The actual volume mount is performed by **containerd**, which runs in the worker's *main* namespace where `/hostdev` **is** present. Clearing `hostPathType` to `""` skips the kubelet precheck and lets containerd bind the live node — the same path the Coral's live `/dev/bus/usb` nodes already take.

The Coral sidesteps this entirely because its mount lives **under `/dev`** and uses `hostPathType: Directory` (only checks the dir exists).

## Verification

Throwaway privileged busybox pod on worker-2 with `hostPath: /hostdev/ttyACM0`, `type: ""`:
```
crw-rw----  1 root  20  166, 0  /dev/zstick
MOUNT_OK
```
Mount succeeds; live char device present.

## Change

WSL overlay adds one patch op: `hostPathType` → `""`. MS-01 keeps `CharDevice` (udev runs there; normal `/dev` node).

Post-merge: Flux reconcile → zwave-js-ui-0 should go Running (worker-2 already has the `/hostdev` bind from #1313).