### PR TITLE
feat(monitoring): Faro frontend observability — Alloy + Tempo, Loki on filesystem

### DIFF
--- a/kubernetes/apps/monitoring/alloy/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/alloy/app/helmrelease.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: alloy
+  namespace: monitoring
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: alloy
+      version: 1.9.0
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: flux-system
+      interval: 30m
+  values:
+    # Central collector for browser RUM, not a per-node agent — run a single
+    # Deployment replica rather than the chart's default DaemonSet.
+    controller:
+      type: deployment
+      replicas: 1
+
+    alloy:
+      # WAL/data is ephemeral (Faro telemetry is forwarded straight through to
+      # Tempo/Loki, nothing is buffered long-term), so the default emptyDir at
+      # /tmp/alloy is fine.
+      configMap:
+        create: true
+        content: |-
+          // ---------------------------------------------------------------
+          // Faro receiver — the HTTP endpoint browser JS (the Faro SDK) POSTs
+          // RUM payloads to. Split into traces -> Tempo and logs/exceptions ->
+          // Loki below. uiPathPrefix-style routing isn't needed; the ingress
+          // sends the whole host to this port.
+          // ---------------------------------------------------------------
+          faro.receiver "frontend" {
+            server {
+              listen_address           = "0.0.0.0"
+              listen_port              = 12347
+              cors_allowed_origins     = ["https://sites.${SECRET_DOMAIN}"]
+              max_allowed_payload_size = "10MiB"
+            }
+
+            output {
+              logs   = [loki.write.faro.receiver]
+              traces = [otelcol.exporter.otlp.tempo.input]
+            }
+          }
+
+          // Frontend logs + exceptions -> Loki gateway. The receiver attaches
+          // app/session/page labels from the Faro payload.
+          loki.write "faro" {
+            endpoint {
+              url = "http://loki-gateway.monitoring.svc.cluster.local:80/loki/api/v1/push"
+            }
+          }
+
+          // Frontend traces -> Tempo over OTLP gRPC. tls.insecure because this
+          // is an in-cluster plaintext hop.
+          otelcol.exporter.otlp "tempo" {
+            client {
+              endpoint = "tempo.monitoring.svc.cluster.local:4317"
+              tls {
+                insecure = true
+              }
+            }
+          }
+
+      # Expose the Faro receiver port on the container + Service so the ingress
+      # below (and in-cluster clients) can reach it. 12345 (UI/metrics) is
+      # exposed automatically by enableHttpServerPort.
+      extraPorts:
+        - name: faro
+          port: 12347
+          targetPort: 12347
+          protocol: TCP
+
+      resources:
+        requests:
+          cpu: 25m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
+
+    # PUBLIC ingress for the Faro port. Browser JS on sites.${SECRET_DOMAIN}
+    # POSTs telemetry here, so it must be reachable from the LAN/internet, not
+    # just internally — hence the `nginx` (external, cloudflared-fronted) class
+    # and the public ${SECRET_DOMAIN}, matching the sites it serves. The chart
+    # points this Ingress at faroPort automatically.
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      faroPort: 12347
+      annotations:
+        external-dns.alpha.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
+      hosts:
+        - faro.${SECRET_DOMAIN}
+      path: /
+      pathType: Prefix
+      tls:
+        - hosts:
+            - faro.${SECRET_DOMAIN}
+
+    serviceMonitor:
+      enabled: ${SERVICE_MONITOR_ENABLED}

--- a/kubernetes/apps/monitoring/alloy/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/alloy/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/monitoring/alloy/ks.yaml
+++ b/kubernetes/apps/monitoring/alloy/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: alloy
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: "./kubernetes/apps/monitoring/alloy/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false # no flux ks dependents
+  dependsOn:
+    # Alloy forwards traces->tempo and logs->loki; gate on both being up so
+    # its config's endpoints resolve.
+    - name: tempo
+    - name: loki

--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -118,7 +118,19 @@ spec:
           - access: proxy
             name: Loki
             type: loki
+            uid: loki
             url: http://loki-gateway.monitoring.svc.cluster.local:80
+          - access: proxy
+            name: Tempo
+            type: tempo
+            uid: tempo
+            url: http://tempo.monitoring.svc.cluster.local:3200
+            jsonData:
+              # Trace -> Logs correlation: jump from a Tempo span to the Faro
+              # logs Alloy wrote to Loki for the same trace.
+              tracesToLogsV2:
+                datasourceUid: loki
+                filterByTraceID: true
           - name: Alertmanager
             type: alertmanager
             access: proxy

--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -14,6 +14,13 @@ resources:
   - ./unms-exporter/ks.yaml
   - ./snmp-exporter/ks.yaml
   - ./plausible-exporter/ks.yaml
-# loki, thanos, and vector are MS-01 only (loki + thanos need Rook Ceph
-# S3 buckets, vector-aggregator dependsOn loki). Added back via
+  # Faro frontend-observability stack — runs on every cluster. loki now uses
+  # the filesystem backend (single-binary) instead of Rook S3, so it's viable
+  # on WSL too; tempo is filesystem-backed single-binary; alloy receives Faro
+  # SDK telemetry and fans it out to tempo (traces) + loki (logs).
+  - ./loki/ks.yaml
+  - ./tempo/ks.yaml
+  - ./alloy/ks.yaml
+# thanos and vector remain MS-01 only (thanos needs a Rook Ceph S3 bucket;
+# vector-aggregator dependsOn loki). Added back via
 # kubernetes/clusters/ms-01/apps/kustomization.yaml.

--- a/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
@@ -16,180 +16,106 @@ spec:
         namespace: flux-system
       interval: 30m
   values:
+    # Single-binary + filesystem. The previous config targeted Rook-Ceph S3
+    # (MS-01-only) with a Loki-2.x schema (boltdb-shipper / v11 / shared_store)
+    # that the chart's Loki-3.x image no longer accepts, so it never ran.
+    # Single-binary on a local PVC drops the object-store dependency entirely,
+    # which is what makes Loki viable on WSL (no shared FS, no Rook S3) while
+    # staying portable to MS-01.
+    deploymentMode: SingleBinary
+
     loki:
-      structuredConfig:
-        auth_enabled: false
+      auth_enabled: false
 
-        server:
-          log_level: info
-          http_listen_port: 3100
-          grpc_listen_port: 9095
+      commonConfig:
+        path_prefix: /var/loki
+        # Single replica — one ingester, no ring quorum to satisfy.
+        replication_factor: 1
 
-          grpc_server_max_recv_msg_size: 8388608
-          grpc_server_max_send_msg_size: 8388608
+      storage:
+        type: filesystem
+        filesystem:
+          chunks_directory: /var/loki/chunks
+          rules_directory: /var/loki/rules
 
-        memberlist:
-          join_members: ["loki-memberlist"]
+      schemaConfig:
+        configs:
+          - from: "2024-04-01"
+            store: tsdb
+            object_store: filesystem
+            schema: v13
+            index:
+              prefix: loki_index_
+              period: 24h
 
-        limits_config:
-          retention_period: 14d
-          enforce_metric_name: false
-          reject_old_samples: true
-          reject_old_samples_max_age: 168h
-          max_cache_freshness_per_query: 10m
-          split_queries_by_interval: 15m
-          per_stream_rate_limit: 64M
-          per_stream_rate_limit_burst: 128M
-          ingestion_rate_mb: 64
-          ingestion_burst_size_mb: 128
-          shard_streams:
-            enabled: true
+      limits_config:
+        retention_period: 14d
+        reject_old_samples: true
+        reject_old_samples_max_age: 168h
+        max_cache_freshness_per_query: 10m
+        split_queries_by_interval: 15m
+        per_stream_rate_limit: 64M
+        per_stream_rate_limit_burst: 128M
+        ingestion_rate_mb: 64
+        ingestion_burst_size_mb: 128
+        shard_streams:
+          enabled: true
 
-        schema_config:
-          configs:
-            - from: "2021-08-01"
-              store: boltdb-shipper
-              object_store: s3
-              schema: v11
-              index:
-                prefix: loki_index_
-                period: 24h
+      compactor:
+        working_directory: /var/loki/compactor
+        compaction_interval: 10m
+        retention_enabled: true
+        retention_delete_delay: 2h
+        retention_delete_worker_count: 150
+        delete_request_store: filesystem
 
-        common:
-          path_prefix: /var/loki
-          replication_factor: 3
-          storage:
-            s3:
-              s3: null
-              insecure: true
-              s3forcepathstyle: true
-          ring:
-            kvstore:
-              store: memberlist
+      ingester:
+        chunk_encoding: snappy
 
-        ruler:
-          enable_api: true
-          enable_alertmanager_v2: true
-          alertmanager_url: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093
-          storage:
-            type: local
-            local:
-              directory: /rules
-          rule_path: /rules
-          ring:
-            kvstore:
-              store: memberlist
+      analytics:
+        reporting_enabled: false
 
-        distributor:
-          ring:
-            kvstore:
-              store: memberlist
+    # Run the single-binary target; zero out the SimpleScalable pools.
+    singleBinary:
+      replicas: 1
+      persistence:
+        enabled: true
+        size: 20Gi
+        storageClass: "${STORAGE_CLASS_DEFAULT}"
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
 
-        compactor:
-          working_directory: /var/loki/boltdb-shipper-compactor
-          shared_store: s3
-          compaction_interval: 10m
-          retention_enabled: true
-          retention_delete_delay: 2h
-          retention_delete_worker_count: 150
+    write:
+      replicas: 0
+    read:
+      replicas: 0
+    backend:
+      replicas: 0
 
-        ingester:
-          max_chunk_age: 1h
-          lifecycler:
-            ring:
-              kvstore:
-                store: memberlist
-
-        analytics:
-          reporting_enabled: false
-
-      podAnnotations:
-        secret.reloader.stakater.com/reload: loki-secrets
-
+    # The gateway (nginx) fronts the single-binary and provides the stable
+    # loki-gateway Service that Grafana and Alloy write/read against.
     gateway:
-      replicas: 3
-      affinity: |
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    {{- include "loki.gatewaySelectorLabels" . | nindent 12 }}
-                topologyKey: kubernetes.io/hostname
       enabled: true
+      replicas: 1
       image:
         registry: ghcr.io
         repository: nginxinc/nginx-unprivileged
         tag: 1.27-alpine
-      ingress:
-        enabled: true
-        ingressClassName: "nginx-internal"
-        annotations:
-          nginx.ingress.kubernetes.io/whitelist-source-range: |
-            10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
-        hosts:
-          - host: &host "loki.${INTERNAL_DOMAIN}"
-            paths:
-              - path: /
-                pathType: Prefix
-        tls:
-          - hosts:
-              - *host
 
-    write:
-      replicas: 3
-      affinity: |
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    {{- include "loki.writeSelectorLabels" . | nindent 12 }}
-                topologyKey: kubernetes.io/hostname
-      persistence:
-        size: 20Gi
-        storageClass: "${STORAGE_CLASS_DEFAULT}"
+    # memcached chunks/results caches default on and spin up extra pods that a
+    # low-traffic homelab doesn't need.
+    chunksCache:
+      enabled: false
+    resultsCache:
+      enabled: false
 
-    read:
-      replicas: 3
-      affinity: |
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    {{- include "loki.readSelectorLabels" . | nindent 12 }}
-                topologyKey: kubernetes.io/hostname
-      extraVolumeMounts:
-        - name: rules
-          mountPath: /rules
-      extraVolumes:
-        - name: rules
-          emptyDir: {}
-
-    backend:
-      replicas: 3
-      affinity: |
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    {{- include "loki.backendSelectorLabels" . | nindent 12 }}
-                topologyKey: kubernetes.io/hostname
-      extraVolumeMounts:
-        - name: rules
-          mountPath: /rules
-      extraVolumes:
-        - name: rules
-          emptyDir: {}
-      persistence:
-        size: 20Gi
-        storageClass: "${STORAGE_CLASS_DEFAULT}"
+    # No bundled MinIO — we use the filesystem backend.
+    minio:
+      enabled: false
 
     monitoring:
       dashboards:
@@ -203,25 +129,11 @@ spec:
         enabled: false
         grafanaAgent:
           installOperator: false
-      lokiCanary:
-        enabled: false
+
+    # lokiCanary + test are top-level keys in this chart (not under
+    # `monitoring`); a low-traffic homelab doesn't need the synthetic
+    # write/read probe DaemonSet.
+    lokiCanary:
+      enabled: false
     test:
       enabled: false
-
-  valuesFrom:
-    - kind: ConfigMap
-      name: s3-loki-bucket
-      valuesKey: BUCKET_NAME
-      targetPath: loki.structuredConfig.common.storage.s3.bucketnames
-    - kind: Secret
-      name: loki-secrets
-      valuesKey: BUCKET_HOST
-      targetPath: loki.structuredConfig.common.storage.s3.endpoint
-    - kind: Secret
-      name: s3-loki-bucket
-      valuesKey: AWS_ACCESS_KEY_ID
-      targetPath: loki.structuredConfig.common.storage.s3.access_key_id
-    - kind: Secret
-      name: s3-loki-bucket
-      valuesKey: AWS_SECRET_ACCESS_KEY
-      targetPath: loki.structuredConfig.common.storage.s3.secret_access_key

--- a/kubernetes/apps/monitoring/loki/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/loki/app/kustomization.yaml
@@ -3,8 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: monitoring
 resources:
-  - ./secrets.sops.yaml
   - ./helmrelease.yaml
   - ./prometheus-rule.yaml
-# s3-loki-bucket.yaml uses ObjectBucketClaim which only exists when Rook
-# is installed. Added back per-cluster via kubernetes/clusters/ms-01/apps/.
+# Loki now uses the filesystem backend (single-binary), so it no longer needs
+# the Rook S3 ObjectBucketClaim (s3-loki-bucket.yaml) or the loki-secrets /
+# loki ExternalSecret. Those files are kept in-tree but unreferenced in case a
+# future object-store deployment on MS-01 wants them back.

--- a/kubernetes/apps/monitoring/tempo/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/tempo/app/helmrelease.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tempo
+  namespace: monitoring
+spec:
+  interval: 30m
+  chart:
+    spec:
+      # grafana/tempo is the single-binary (monolithic) chart — ideal for a
+      # low-traffic homelab. (grafana/tempo-distributed is the microservices
+      # variant; we deliberately don't use it.)
+      chart: tempo
+      version: 1.24.4
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: flux-system
+      interval: 30m
+  values:
+    tempo:
+      # Anonymous usage reporting off, matching loki/grafana here.
+      reportingEnabled: false
+      retention: 168h # 7d — span retention for the homelab
+      storage:
+        trace:
+          # Local filesystem backend on the PVC mounted below. No S3/MinIO
+          # dependency, so this runs identically on WSL and MS-01.
+          backend: local
+          local:
+            path: /var/tempo/traces
+          wal:
+            path: /var/tempo/wal
+      # Receivers are left at the chart default, which already enables OTLP on
+      # :4317 (gRPC) / :4318 (HTTP) — that's the only one Alloy uses to forward
+      # Faro traces. The chart's default set also opens jaeger/zipkin listeners;
+      # they're left in place (the chart's Service template hard-references the
+      # jaeger block, so nulling it breaks rendering) and simply go unused.
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
+
+    persistence:
+      enabled: true
+      storageClassName: "${STORAGE_CLASS_DEFAULT}"
+      accessModes:
+        - ReadWriteOnce
+      size: 10Gi
+
+    # ServiceMonitor for kube-prometheus-stack to scrape Tempo's own metrics.
+    serviceMonitor:
+      enabled: ${SERVICE_MONITOR_ENABLED}

--- a/kubernetes/apps/monitoring/tempo/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/tempo/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/monitoring/tempo/ks.yaml
+++ b/kubernetes/apps/monitoring/tempo/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tempo
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: "./kubernetes/apps/monitoring/tempo/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true # alloy + grafana datasource read from tempo
+  dependsOn:
+    - name: kube-prometheus-stack

--- a/kubernetes/clusters/ms-01/apps/kustomization.yaml
+++ b/kubernetes/clusters/ms-01/apps/kustomization.yaml
@@ -9,8 +9,9 @@ resources:
   - ../../../apps/kube-system/cilium/ks.yaml
   - ../../../apps/storage/rook-ceph/rook-ceph-operator
   - ../../../apps/storage/rook-ceph/cluster
-  # MS-01-only: loki, thanos, vector. They depend on Rook S3 buckets.
-  - ../../../apps/monitoring/loki/ks.yaml
+  # MS-01-only: thanos + vector. thanos needs a Rook S3 bucket; vector's
+  # aggregator dependsOn loki. (loki itself moved to the shared monitoring
+  # kustomization now that it uses the filesystem backend.)
   - ../../../apps/monitoring/thanos/ks.yaml
   - ../../../apps/monitoring/vector/ks.yaml
   # node-feature-discovery is MS-01-only too — needed for hardware-aware
@@ -22,7 +23,6 @@ resources:
   # also needs a kustomize patch to add the `backup.barmanObjectStore`
   # block back; TODO when MS-01 is racked and backups are needed.
   - ../../../apps/databases/cloudnative-pg/ks-cluster-backup.yaml
-  # ObjectBucketClaims for thanos/loki (cnpg's bucket is created via
-  # the ks-cluster-backup path above).
+  # ObjectBucketClaim for thanos (cnpg's bucket is created via the
+  # ks-cluster-backup path above; loki no longer needs an S3 bucket).
   - ../../../apps/monitoring/thanos/app/s3-thanos-bucket.yaml
-  - ../../../apps/monitoring/loki/app/s3-loki-bucket.yaml


### PR DESCRIPTION
## What

Adds the open-source Grafana stack for frontend **RUM, error tracking, and distributed tracing** from our sites, and gets **Loki running** in the process.

| App | Chart | Mode | Storage |
| --- | --- | --- | --- |
| **Tempo** | `grafana/tempo` 1.24.4 | single-binary (monolithic) | local filesystem on a `${STORAGE_CLASS_DEFAULT}` PVC |
| **Alloy** | `grafana/alloy` 1.9.0 | single Deployment | ephemeral (forwards straight through) |
| **Loki** | `grafana/loki` 7.0.0 | **single-binary + filesystem** (was SimpleScalable+S3) | `${STORAGE_CLASS_DEFAULT}` PVC |

## How it flows

```
browser (Faro SDK on sites.${SECRET_DOMAIN})
   │  HTTPS POST
   ▼
faro.${SECRET_DOMAIN}  ──nginx (external/cloudflared)──▶  Alloy faro.receiver :12347
   ├─ traces  ──OTLP gRPC──▶  tempo.monitoring:4317
   └─ logs/exceptions  ──▶   loki-gateway.monitoring:80
                                     ▲
                          Grafana (Tempo + Loki datasources, trace→logs correlation)
```

## Key decisions

- **Public endpoint uses the existing external-domain variable, `\${SECRET_DOMAIN}\`.** In this repo `\${SECRET_DOMAIN}\` *is* the public domain — cloudflared routes `*.\${SECRET_DOMAIN}\` to the `nginx` ingress class (that's how `sites.\${SECRET_DOMAIN}\` / `oauth2.\${SECRET_DOMAIN}\` are reachable). `\${INTERNAL_DOMAIN}\` is LAN-only (`nginx-internal`). Alloy's Faro receiver must be browser-reachable, so it's on `nginx` + `faro.\${SECRET_DOMAIN}\`. No new variable needed. CORS is scoped to `https://sites.\${SECRET_DOMAIN}\`.
- **Loki was dead, not dormant.** The previous config paired a Loki-2.x schema (`boltdb-shipper` / `v11` / `shared_store`) with the chart's Loki-3.x image, which rejects it — it could never start on either cluster. Rewriting to single-binary + filesystem drops the Rook-S3 dependency, so Loki now ships from the **shared** `monitoring` kustomization on every cluster instead of being MS-01-only. Thanos + Vector remain MS-01-only.
- **Tempo receivers left at chart default.** The default set already enables OTLP on :4317/:4318 (the only one Alloy uses). The chart's Service template hard-references the jaeger block, so nulling it breaks rendering; the unused listeners are harmless.

## Validation (non-mutating, per AGENTS.md)

- ✅ `kustomize build` of both `clusters/{wsl,ms-01}/apps` overlays
- ✅ `helm template` of all three charts with the exact HelmRelease values — confirmed Loki single-binary StatefulSet + filesystem schema (canary off), Tempo OTLP:4317 + PVC, Alloy Faro port/Service/ingress + config
- ✅ envsubst substitution check for `\${SECRET_DOMAIN}\`, `\${STORAGE_CLASS_DEFAULT}\`, `\${SERVICE_MONITOR_ENABLED}\`

## Not in scope

- Faro JS SDK wiring (separate tnwks-sites repo)
- No `kubectl apply` — Flux reconciles on merge.