### PR TITLE
fix(wsl): give worker-2 unless-stopped restart policy so it survives host reboots

### DIFF
--- a/infrastructure/ansible/playbooks/01-talos-bootstrap.yml
+++ b/infrastructure/ansible/playbooks/01-talos-bootstrap.yml
@@ -239,7 +239,13 @@
                 hostname: "{{ worker_name }}"
                 image: "{{ w2_info.container.Config.Image }}"
                 state: started
-                restart_policy: "no"
+                # Match the restart policy talosctl sets on the stock nodes
+                # (controlplane-1, worker-1 both get `unless-stopped`). The
+                # recreate here previously hardcoded `no`, so worker-2 alone
+                # stayed dead after a Docker/WSL restart while the other two
+                # came back — wedging every pod pinned to it (grafana PVC,
+                # alertmanager, frigate/zwave USB) until a manual docker start.
+                restart_policy: unless-stopped
                 privileged: true
                 read_only: true
                 shm_size: 64M


### PR DESCRIPTION
## Root cause

worker-2 went `Exited (255)` on a Docker/WSL restart ~7h ago and **never came back**, while controlplane-1 and worker-1 auto-recovered one second later. That stranded every pod pinned to worker-2 and is what produced the **Grafana 503** (its `local-path` PVC is node-affined to worker-2, so the pod couldn't reschedule and there was zero ready ingress backend), plus `alertmanager-0` Pending and the frigate/zwave USB workloads down.

The discrepancy was a one-liner. All three node containers stopped at the same instant; the difference was restart policy:

| Node | RestartPolicy | Recovered on reboot? |
|------|---------------|----------------------|
| controlplane-1 | `unless-stopped` | ✅ |
| worker-1 | `unless-stopped` | ✅ |
| **worker-2** | **`no`** | ❌ stayed dead |

`talosctl cluster create docker` sets `unless-stopped` on the nodes it creates. But the bootstrap playbook **recreates worker-2** to add USB passthrough (`--device` → rslave binds) + the bulk-storage mount, and that recreate task hardcoded `restart_policy: "no"`. So worker-2 — the only recreated node — was the only one that didn't survive a host restart.

## Fix

`infrastructure/ansible/playbooks/01-talos-bootstrap.yml`: change the worker-2 recreate task to `restart_policy: unless-stopped`, matching the stock nodes.

Because the playbook only re-runs on bootstrap, I also fixed the **live** container in place:

```
docker update --restart unless-stopped homelab-wsl-worker-2
```

`docker update` only rewrites the policy flag — no recreate, no restart, USB passthrough undisturbed. All three nodes now report `unless-stopped`, so the running cluster is already covered.

## Validation

- ✅ `ansible-playbook --syntax-check` passes
- ✅ live verification: all three node containers now show `unless-stopped`
- ✅ cluster recovered — grafana `3/3 Running`, alertmanager/node-exporter back, faro stack (alloy/loki/tempo) healthy

## Not covered

zwave-js-ui needs its serial port re-set in the UI (`/hostdev/ttyACM0`) — its `settings.json` wasn't in the PVC. That's a separate, UI-only config task, intentionally out of scope here.