### PR TITLE
fix(frigate): move recording cache to tmpfs, off the shared sdd disk

### DIFF
--- a/kubernetes/apps/production/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/production/frigate/app/helmrelease.yaml
@@ -117,12 +117,27 @@ spec:
           - path: /config/config.yml
             subPath: config.yml
             readOnly: true
+      # Frame shared-memory. Frigate keeps decoded frames in /dev/shm; a
+      # RAM-backed volume keeps that off disk.
       cache:
         type: emptyDir
         medium: Memory
-        sizeLimit: 4Gi
+        sizeLimit: 2Gi
         globalMounts:
           - path: /dev/shm
+      # Recording segment cache. Frigate writes every record-role segment to
+      # /tmp/cache first, then copies the kept ones to /media. With no volume
+      # here it lands on the container overlay (the WSL sdd ext4 vhdx that also
+      # backs /var/lib/docker and every local-path PVC), so ~10 cameras of
+      # continuous segment write+read churn saturate that one shared disk —
+      # NodeDiskIOSaturation on sdd across all three nodes. A RAM-backed mount
+      # is Frigate's documented best practice and removes the churn from disk.
+      tmp-cache:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 2Gi
+        globalMounts:
+          - path: /tmp/cache
       usb:
         type: hostPath
         hostPath: /dev/bus/usb


### PR DESCRIPTION
## Symptom

`NodeDiskIOSaturation` firing on device **`sdd`** across all three WSL nodes; Task Manager showing sustained disk **read** spikes; Grafana slow to load.

## Diagnosis

`sdd` is the single WSL2 ext4 vhdx (C:) that backs `/`, **`/var/lib/docker`**, and every `local-path` PVC. All three Talos node containers run on it, so one saturated disk = three nodes alerting. Measured **~1+ GB/s sustained reads** on `sdd` during the incident (`/proc/pressure/io` avg60 ~14).

Two workloads share that disk:
1. **Frigate's recording cache** — Frigate writes every record-role segment to `/tmp/cache`, then copies kept ones to `/media` (E:). `/tmp/cache` had **no volume**, so it sat on the container overlay = `sdd`. ~10 cameras → continuous segment write+read churn. (`df /tmp/cache` confirmed overlay; 9 active `.mp4` segments at diagnosis time.)
2. **Loki + Tempo** (my recent PRs) — now filesystem-backed on `local-path` PVCs (also `sdd`); Grafana queries read them, which is the "Grafana slow + disk hammered" correlation.

Neither alone necessarily saturates `sdd`; together they tip it over — which is why it appeared right after worker-2 (Frigate) came back and the monitoring stack landed.

**Honest scope:** per-pod byte attribution wasn't cleanly obtainable (reads surface at the WSL vhdx layer, below docker's per-container block accounting). "disk saturated, on sdd, Frigate cache is on sdd" is measured; "Loki query reads are a co-contributor" is correlation. This PR removes the clearest, highest-churn offender first.

## Fix

Mount a **RAM-backed emptyDir at `/tmp/cache`** — Frigate's documented best practice. The recording cache never touches disk; only the final copy to `/media` (E: bulk) does. RAM budget held flat: the previous single 4Gi `/dev/shm` volume is split into 2Gi (frames) + 2Gi (segment cache), well under the pod's 8Gi limit (current RSS ~1.6Gi).

## Validation

- ✅ `kustomize build` of frigate/app and the full WSL overlay (frigate is patched there) both pass
- ✅ both RAM mounts render (`/dev/shm`, `/tmp/cache`, `medium: Memory`)

If `sdd` is still hot after this reconciles, the follow-up lever is moving the Loki/Tempo PVCs to `local-path-bulk` (E:) — deferred until we see the effect of removing the Frigate churn.