### PR TITLE
fix(grafana): raise memory limit 219M→768M to stop page-cache thrash

### DIFF
--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -304,11 +304,19 @@ spec:
       pspEnabled: false
 
     resources:
+      # 219M was far too low: Grafana's working set (binary + multiple
+      # datasources + dashboard/datasource sidecars + image-renderer) exceeds
+      # it, so the kernel evicted its file-backed pages the moment they loaded
+      # and re-read them from disk on the next access. That thrash showed up as
+      # sustained multi-GB/s reads on the shared WSL vhdx (sdd) — 3 TB of
+      # read_bytes against only 276 MB of actual read syscalls, with
+      # workingset_refault_file in the hundreds of millions and memory.max hit
+      # 16M times. Give it real headroom so its working set stays resident.
       limits:
-        memory: 219M
+        memory: 768M
       requests:
         cpu: 23m
-        memory: 127M
+        memory: 256M
 
     serviceMonitor:
       enabled: true


### PR DESCRIPTION
## TL;DR
The "spiky disk pressure" was **Grafana page-cache thrashing against a 219M memory limit that's far too small** — re-reading its own working set from the shared WSL vhdx (`sdd`) over and over. This is the spiky-reader half of the IO saturation; #1318 (Frigate cache → tmpfs) was a separate, real contributor to the *baseline*.

## How it was found
Caught the live reader from inside worker-2: the `grafana` process showed
```
read_bytes:  3,081,327,831,985   (3.08 TB)
rchar:             276,538,443   (276 MB actual read syscalls)
```
~11,000x amplification → not real reads, **disk thrash**. Its cgroup confirmed why:
```
memory.max:      218,996,736   (= limits.memory: 219M)
memory.current:  218,836,992   (99.9% — pinned at the limit)
workingset_refault_file: 766,714,876
pgscan_direct:         1,463,159,935
memory.events max:        16,458,698   (limit hit 16.4M times)
```
Grafana's working set (binary + multiple datasources + the `grafana-sc-dashboard` / `grafana-sc-datasources` sidecars + image-renderer) doesn't fit in 219M, so the kernel evicts its file pages instantly and re-faults them from disk on the next access — forever.

## Why it surfaced "after the recent changes"
The 219M limit is old, but two recent things tipped it over the edge into *permanent* thrash:
1. the Grafana pod was **recreated** when worker-2 returned from the dead-node incident (PR #1316), and
2. I added the **Tempo datasource** (PR for Faro) — more provisioning/query surface, a bit more working set.

On WSL the backing disk is the single ext4 vhdx (`sdd`, physically on the E: NVMe) shared by every node container and `local-path` PVC, so one pod's thrash saturates IO for all three nodes → `NodeDiskIOSaturation` everywhere + slow Grafana.

## Fix
`limits.memory 219M → 768M`, `requests.memory 127M → 256M`. Enough headroom for the working set to stay resident.

## Validation
- ✅ `kustomize build` of grafana/app passes
- After merge+reconcile I'll confirm: `memory.current` settles below `memory.max`, `workingset_refault_file` stops climbing, and `sdd` read spikes drop.

## Topology note (corrects an earlier wrong suggestion)
I'd floated "move Loki/Tempo to `local-path-bulk`" — that's useless: the vhdx was relocated to E: (`Move-WslDiskToE.ps1`) and `local-path-bulk` is also E:, same physical NVMe. The real issue was never *which* SSD; it was the thrash volume. Scrapped.