### PR TITLE
fix(auth): remove chown-scratch init container from onboard

### DIFF
--- a/kubernetes/apps/auth/onboard/app/deployment.yaml
+++ b/kubernetes/apps/auth/onboard/app/deployment.yaml
@@ -26,35 +26,7 @@ spec:
         fsGroup: 101
         seccompProfile:
           type: RuntimeDefault
-      # WSL Talos doesn't chown emptyDir on fsGroup, so the writable scratch
-      # dirs nginx-unprivileged needs (/tmp, /var/cache/nginx) come up
-      # root-owned and read-only-root-fs nginx can't write to them. Init
-      # container chowns them to uid 101 before the main container starts.
-      # /var/run is intentionally not mounted — nginx-unprivileged writes
-      # its pid to /tmp/nginx.pid by default, and /var/run is a symlink to
-      # /run in this image which chown -R would try to dereference.
-      initContainers:
-        - name: chown-scratch
-          image: nginxinc/nginx-unprivileged:1.27-alpine
-          command:
-            - /bin/sh
-            - -c
-            - chown -R 101:101 /tmp /var/cache/nginx
-          securityContext:
-            runAsUser: 0
-            runAsNonRoot: false
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - ALL
-              add:
-                - CHOWN
-          volumeMounts:
-            - name: tmp
-              mountPath: /tmp
-            - name: var-cache-nginx
-              mountPath: /var/cache/nginx
+      # emptyDirs are owned by fsGroup (101) at creation — no init container needed
       containers:
         - name: nginx
           image: nginxinc/nginx-unprivileged:1.27-alpine


### PR DESCRIPTION
The `chown-scratch` init container has been crash-looping for 2+ days, blocking both onboard replicas from starting. It runs as root with CAP_CHOWN to fix emptyDir ownership, but pod security is denying the privilege escalation at runtime.

Since `fsGroup: 101` is already set on the pod spec, kubelet handles group ownership of emptyDir volumes natively — the init container is redundant.

Removes the init container entirely. Pods should come up clean once Flux reconciles.