### PR TITLE
fix(monitoring): bump tempo memory limit 512Mi→1Gi to resolve OOM

### DIFF
--- a/kubernetes/apps/monitoring/tempo/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/tempo/app/helmrelease.yaml
@@ -40,9 +40,9 @@ spec:
       resources:
         requests:
           cpu: 50m
-          memory: 128Mi
+          memory: 256Mi
         limits:
-          memory: 512Mi
+          memory: 1Gi
 
     persistence:
       enabled: true


### PR DESCRIPTION
Tempo has been repeatedly OOM-killed at its 512Mi limit. Bumps to 1Gi limit / 256Mi request to give headroom for WAL flushes and trace ingestion.