### PR TITLE
fix(monitoring): scope OOMKilled alert to active restarts

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/addons/alerts/oomkilled.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/addons/alerts/oomkilled.yaml
@@ -9,9 +9,13 @@ spec:
       rules:
         - alert: OOMKilled
           annotations:
-            summary: Container {{ $labels.container }} of pod {{ $labels.pod }} in namespace {{ $labels.namespace }} is out of memory
-            message: Container {{ $labels.container }} of pod {{ $labels.pod }} in namespace {{ $labels.namespace }} is out of memory
-            description: Container {{ $labels.container }} of pod {{ $labels.pod }} in namespace {{ $labels.namespace }} is out of memory
-          expr: kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}==1
+            summary: Container {{ $labels.container }} of pod {{ $labels.pod }} in namespace {{ $labels.namespace }} was OOM killed
+            message: Container {{ $labels.container }} of pod {{ $labels.pod }} in namespace {{ $labels.namespace }} was OOM killed recently
+            description: Container {{ $labels.container }} of pod {{ $labels.pod }} in namespace {{ $labels.namespace }} was OOM killed and has restarted within the last hour
+          expr: |
+            (kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} == 1)
+            and on(namespace, pod, container)
+            (increase(kube_pod_container_status_restarts_total[1h]) > 0)
+          for: 5m
           labels:
             severity: critical


### PR DESCRIPTION
## Problem
The OOMKilled alert rule used `kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} == 1` with no time window. Once a pod was OOM killed, it stayed firing indefinitely even after recovery — leading to 25+ stale critical alerts from the June 17 event.

## Fix
Now requires **both** conditions:
- Last termination reason is OOMKilled
- Container has restarted within the last hour (`increase(restarts_total[1h]) > 0`)

Also adds `for: 5m` to debounce transient blips.

## Result
Alerts auto-resolve ~1h after pods stabilize. No more permanent noise from one-time OOM events.